### PR TITLE
Allow passing commands as Bytes objects.

### DIFF
--- a/redis-test/src/lib.rs
+++ b/redis-test/src/lib.rs
@@ -261,7 +261,7 @@ impl ConnectionLike for MockRedisConnection {
 
 #[cfg(feature = "aio")]
 impl AioConnectionLike for MockRedisConnection {
-    fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
+    fn req_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
         let packed_cmd = cmd.get_packed_command();
         let response = <MockRedisConnection as ConnectionLike>::req_packed_command(
             self,
@@ -270,7 +270,7 @@ impl AioConnectionLike for MockRedisConnection {
         future::ready(response).boxed()
     }
 
-    fn req_packed_commands<'a>(
+    fn req_pipeline<'a>(
         &'a mut self,
         cmd: &'a Pipeline,
         offset: usize,

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -37,7 +37,7 @@ sha1_smol = { version = "1.0", optional = true }
 combine = { version = "4.6", default-features = false, features = ["std"] }
 
 # Only needed for AIO
-bytes = { version = "1" }
+bytes = { version = "1", optional = true }
 futures-util = { version = "0.3.15", default-features = false, optional = true }
 pin-project-lite = { version = "0.2", optional = true }
 tokio-util = { version = "0.7", optional = true }

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -37,7 +37,7 @@ sha1_smol = { version = "1.0", optional = true }
 combine = { version = "4.6", default-features = false, features = ["std"] }
 
 # Only needed for AIO
-bytes = { version = "1", optional = true }
+bytes = { version = "1" }
 futures-util = { version = "0.3.15", default-features = false, optional = true }
 pin-project-lite = { version = "0.2", optional = true }
 tokio-util = { version = "0.7", optional = true }

--- a/redis/src/aio/connection.rs
+++ b/redis/src/aio/connection.rs
@@ -187,7 +187,7 @@ impl<C> ConnectionLike for Connection<C>
 where
     C: Unpin + AsyncRead + AsyncWrite + Send,
 {
-    fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
+    fn req_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
         (async move {
             if self.pubsub {
                 self.exit_pubsub().await?;
@@ -200,7 +200,7 @@ where
         .boxed()
     }
 
-    fn req_packed_commands<'a>(
+    fn req_pipeline<'a>(
         &'a mut self,
         cmd: &'a crate::Pipeline,
         offset: usize,

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -215,11 +215,11 @@ impl ConnectionManager {
 }
 
 impl ConnectionLike for ConnectionManager {
-    fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
+    fn req_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
         (async move { self.send_packed_command(cmd).await }).boxed()
     }
 
-    fn req_packed_commands<'a>(
+    fn req_pipeline<'a>(
         &'a mut self,
         cmd: &'a crate::Pipeline,
         offset: usize,

--- a/redis/src/aio/mod.rs
+++ b/redis/src/aio/mod.rs
@@ -55,12 +55,11 @@ impl<S> AsyncStream for S where S: AsyncRead + AsyncWrite {}
 pub trait ConnectionLike {
     /// Sends an already encoded (packed) command into the TCP socket and
     /// reads the single response from it.
-    fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value>;
+    fn req_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value>;
 
-    /// Sends multiple already encoded (packed) command into the TCP socket
-    /// and reads `count` responses from it.  This is used to implement
-    /// pipelining.
-    fn req_packed_commands<'a>(
+    /// Sends multiple commands into the TCP socket, skips `offset` responses and reads `count` responses from it.
+    /// This is used to implement pipelining.
+    fn req_pipeline<'a>(
         &'a mut self,
         cmd: &'a crate::Pipeline,
         offset: usize,

--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -403,11 +403,11 @@ impl MultiplexedConnection {
 }
 
 impl ConnectionLike for MultiplexedConnection {
-    fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
+    fn req_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
         (async move { self.send_packed_command(cmd).await }).boxed()
     }
 
-    fn req_packed_commands<'a>(
+    fn req_pipeline<'a>(
         &'a mut self,
         cmd: &'a crate::Pipeline,
         offset: usize,

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -454,7 +454,7 @@ where
             let mut result = Ok(());
             for (_, conn) in connections.iter_mut() {
                 let mut conn = conn.clone().await;
-                let value = match conn.req_packed_command(&slot_cmd()).await {
+                let value = match conn.req_command(&slot_cmd()).await {
                     Ok(value) => value,
                     Err(err) => {
                         result = Err(err);
@@ -980,7 +980,7 @@ impl<C> ConnectionLike for ClusterConnection<C>
 where
     C: ConnectionLike + Send + 'static,
 {
-    fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
+    fn req_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
         trace!("req_packed_command");
         let (sender, receiver) = oneshot::channel();
         Box::pin(async move {
@@ -989,9 +989,9 @@ where
                     cmd: CmdArg::Cmd {
                         cmd: Arc::new(cmd.clone()), // TODO Remove this clone?
                         func: |mut conn, cmd| {
-                            Box::pin(async move {
-                                conn.req_packed_command(&cmd).await.map(Response::Single)
-                            })
+                            Box::pin(
+                                async move { conn.req_command(&cmd).await.map(Response::Single) },
+                            )
                         },
                         routing: RoutingInfo::for_routable(cmd),
                     },
@@ -1019,7 +1019,7 @@ where
         })
     }
 
-    fn req_packed_commands<'a>(
+    fn req_pipeline<'a>(
         &'a mut self,
         pipeline: &'a crate::Pipeline,
         offset: usize,
@@ -1035,7 +1035,7 @@ where
                         count,
                         func: |mut conn, pipeline, offset, count| {
                             Box::pin(async move {
-                                conn.req_packed_commands(&pipeline, offset, count)
+                                conn.req_pipeline(&pipeline, offset, count)
                                     .await
                                     .map(Response::Multiple)
                             })

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -683,7 +683,9 @@ where
             }
         };
         if asking {
-            let _ = conn.req_packed_command(Bytes::from_static(b"ASKING")).await;
+            let _ = conn
+                .req_packed_command(Bytes::from_static(b"*1\r\n$6\r\nASKING\r\n"))
+                .await;
         }
         (addr, conn)
     }

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -36,13 +36,14 @@ use crate::{
     aio::{ConnectionLike, MultiplexedConnection},
     cluster::{get_connection_info, parse_slots, slot_cmd},
     cluster_client::{ClusterParams, RetryParams},
-    cluster_routing::{Redirect, Route, RoutingInfo, Slot, SlotMap},
+    cluster_routing::{Redirect, Routable, Route, RoutingInfo, Slot, SlotMap},
     Cmd, ConnectionInfo, ErrorKind, IntoConnectionInfo, RedisError, RedisFuture, RedisResult,
     Value,
 };
 
 #[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
 use crate::aio::{async_std::AsyncStd, RedisRuntime};
+use bytes::Bytes;
 use futures::{
     future::{self, BoxFuture},
     prelude::*,
@@ -116,34 +117,33 @@ struct ClusterConnInner<C> {
 #[derive(Clone)]
 enum CmdArg<C> {
     Cmd {
-        cmd: Arc<Cmd>,
-        func: fn(C, Arc<Cmd>) -> RedisFuture<'static, Response>,
+        cmd: Bytes,
+        func: fn(C, Bytes) -> RedisFuture<'static, Response>,
         routing: Option<RoutingInfo>,
     },
     Pipeline {
-        pipeline: Arc<crate::Pipeline>,
+        pipeline: Bytes,
         offset: usize,
         count: usize,
-        func: fn(C, Arc<crate::Pipeline>, usize, usize) -> RedisFuture<'static, Response>,
+        func: fn(C, Bytes, usize, usize) -> RedisFuture<'static, Response>,
         route: Option<Route>,
     },
 }
 
-fn route_pipeline(pipeline: &crate::Pipeline) -> Option<Route> {
-    fn route_for_command(cmd: &Cmd) -> Option<Route> {
-        match RoutingInfo::for_routable(cmd) {
-            Some(RoutingInfo::Random) => None,
-            Some(RoutingInfo::SpecificNode(route)) => Some(route),
-            Some(RoutingInfo::AllNodes) | Some(RoutingInfo::AllMasters) => None,
-            _ => None,
-        }
+fn route_for_routable<R: Routable>(routable: &R) -> Option<Route> {
+    match RoutingInfo::for_routable(routable) {
+        Some(RoutingInfo::Random) => None,
+        Some(RoutingInfo::SpecificNode(route)) => Some(route),
+        Some(RoutingInfo::AllNodes) | Some(RoutingInfo::AllMasters) => None,
+        _ => None,
     }
+}
 
+fn route_pipeline<'a, R: Routable + 'a>(pipeline: impl Iterator<Item = &'a R>) -> Option<Route> {
     // Find first specific slot and send to it. There's no need to check If later commands
     // should be routed to a different slot, since the server will return an error indicating this.
     pipeline
-        .cmd_iter()
-        .map(route_for_command)
+        .map(route_for_routable)
         .find(|route| route.is_some())
         .flatten()
 }
@@ -535,8 +535,8 @@ where
     }
 
     async fn execute_on_all_nodes(
-        func: fn(C, Arc<Cmd>) -> RedisFuture<'static, Response>,
-        cmd: &Arc<Cmd>,
+        func: fn(C, Bytes) -> RedisFuture<'static, Response>,
+        cmd: Bytes,
         only_primaries: bool,
         core: Core<C>,
     ) -> (OperationTarget, RedisResult<Response>) {
@@ -579,8 +579,8 @@ where
     }
 
     async fn try_cmd_request(
-        cmd: Arc<Cmd>,
-        func: fn(C, Arc<Cmd>) -> RedisFuture<'static, Response>,
+        bytes: Bytes,
+        func: fn(C, Bytes) -> RedisFuture<'static, Response>,
         redirect: Option<Redirect>,
         routing: Option<RoutingInfo>,
         core: Core<C>,
@@ -588,28 +588,28 @@ where
     ) -> (OperationTarget, RedisResult<Response>) {
         let route_option = match routing.as_ref().unwrap_or(&RoutingInfo::Random) {
             RoutingInfo::AllNodes => {
-                return Self::execute_on_all_nodes(func, &cmd, false, core).await
+                return Self::execute_on_all_nodes(func, bytes, false, core).await
             }
             RoutingInfo::AllMasters => {
-                return Self::execute_on_all_nodes(func, &cmd, true, core).await
+                return Self::execute_on_all_nodes(func, bytes, true, core).await
             }
             RoutingInfo::Random => None,
             RoutingInfo::SpecificNode(route) => Some(route),
         };
         let (addr, conn) = Self::get_connection(redirect, route_option, core, asking).await;
-        let result = func(conn, cmd).await;
+        let result = func(conn, bytes).await;
         (addr.into(), result)
     }
 
     async fn try_pipeline_request(
-        pipeline: Arc<crate::Pipeline>,
+        bytes: Bytes,
         offset: usize,
         count: usize,
-        func: fn(C, Arc<crate::Pipeline>, usize, usize) -> RedisFuture<'static, Response>,
+        func: fn(C, Bytes, usize, usize) -> RedisFuture<'static, Response>,
         conn: impl Future<Output = (String, C)>,
     ) -> (OperationTarget, RedisResult<Response>) {
         let (addr, conn) = conn.await;
-        let result = func(conn, pipeline, offset, count).await;
+        let result = func(conn, bytes, offset, count).await;
         (OperationTarget::Node { address: addr }, result)
     }
 
@@ -683,7 +683,7 @@ where
             }
         };
         if asking {
-            let _ = conn.req_packed_command(&crate::cmd::cmd("ASKING")).await;
+            let _ = conn.req_packed_command(Bytes::from_static(b"ASKING")).await;
         }
         (addr, conn)
     }
@@ -976,87 +976,150 @@ where
     }
 }
 
+impl<C> ClusterConnection<C>
+where
+    C: ConnectionLike + Send + 'static,
+{
+    /// Sends an already encoded (packed) command to the connection(s) matching the given [routing],
+    /// or to a random connection if [routing] is `None`.
+    pub async fn send_packed_command(
+        &mut self,
+        cmd: Bytes,
+        routing: Option<RoutingInfo>,
+    ) -> RedisResult<Value> {
+        trace!("send_packed_command");
+        let (sender, receiver) = oneshot::channel();
+        self.0
+            .send(Message {
+                cmd: CmdArg::Cmd {
+                    cmd,
+                    func: |mut conn, cmd| {
+                        Box::pin(
+                            async move { conn.req_packed_command(cmd).await.map(Response::Single) },
+                        )
+                    },
+                    routing,
+                },
+                sender,
+            })
+            .await
+            .map_err(|_| {
+                RedisError::from(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "redis_cluster: Unable to send command",
+                ))
+            })?;
+        receiver
+            .await
+            .unwrap_or_else(|_| {
+                Err(RedisError::from(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "redis_cluster: Unable to receive command",
+                )))
+            })
+            .map(|response| match response {
+                Response::Single(value) => value,
+                Response::Multiple(_) => unreachable!(),
+            })
+    }
+
+    /// Sends multiple encoded (packed) commands to the connection matching the given [route],
+    /// or to a random connection if [route] is `None`. Skips `offset` responses and reads
+    /// `count` responses from it.
+    /// This is used to implement pipelining.
+    pub async fn send_packed_commands(
+        &mut self,
+        pipeline: Bytes,
+        offset: usize,
+        count: usize,
+        route: Option<Route>,
+    ) -> RedisResult<Vec<Value>> {
+        let (sender, receiver) = oneshot::channel();
+        self.0
+            .send(Message {
+                cmd: CmdArg::Pipeline {
+                    pipeline,
+                    offset,
+                    count,
+                    func: |mut conn, pipeline, offset, count| {
+                        Box::pin(async move {
+                            conn.req_packed_commands(pipeline, offset, count)
+                                .await
+                                .map(Response::Multiple)
+                        })
+                    },
+                    route,
+                },
+                sender,
+            })
+            .await
+            .map_err(|_| RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe)))?;
+
+        receiver
+            .await
+            .unwrap_or_else(|_| Err(RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe))))
+            .map(|response| match response {
+                Response::Multiple(values) => values,
+                Response::Single(_) => unreachable!(),
+            })
+    }
+}
+
 impl<C> ConnectionLike for ClusterConnection<C>
 where
     C: ConnectionLike + Send + 'static,
 {
-    fn req_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
-        trace!("req_packed_command");
-        let (sender, receiver) = oneshot::channel();
-        Box::pin(async move {
-            self.0
-                .send(Message {
-                    cmd: CmdArg::Cmd {
-                        cmd: Arc::new(cmd.clone()), // TODO Remove this clone?
-                        func: |mut conn, cmd| {
-                            Box::pin(
-                                async move { conn.req_command(&cmd).await.map(Response::Single) },
-                            )
-                        },
-                        routing: RoutingInfo::for_routable(cmd),
-                    },
-                    sender,
-                })
-                .await
-                .map_err(|_| {
-                    RedisError::from(io::Error::new(
-                        io::ErrorKind::BrokenPipe,
-                        "redis_cluster: Unable to send command",
-                    ))
-                })?;
-            receiver
-                .await
-                .unwrap_or_else(|_| {
-                    Err(RedisError::from(io::Error::new(
-                        io::ErrorKind::BrokenPipe,
-                        "redis_cluster: Unable to receive command",
-                    )))
-                })
-                .map(|response| match response {
-                    Response::Single(value) => value,
-                    Response::Multiple(_) => unreachable!(),
-                })
-        })
+    /// Sends an already encoded (packed) command into the TCP socket and reads
+    /// the single response from it.
+    fn req_packed_command(&mut self, cmd: Bytes) -> RedisFuture<Value> {
+        async move {
+            let value = crate::parse_redis_value(&cmd)?;
+            let routing = RoutingInfo::for_routable(&value);
+            self.send_packed_command(cmd, routing).await
+        }
+        .boxed()
     }
 
+    /// Sends multiple encoded (packed) commands into the TCP socket, skips `offset`
+    /// responses and reads `count` responses from it.
+    /// This is used to implement pipelining.
+    fn req_packed_commands(
+        &mut self,
+        pipeline: Bytes,
+        offset: usize,
+        count: usize,
+    ) -> RedisFuture<Vec<Value>> {
+        async move {
+            let value = crate::parse_redis_value(&pipeline)?;
+            let route = match value {
+                Value::Bulk(values) => route_pipeline(values.iter()),
+                _ => route_for_routable(&value),
+            };
+            self.send_packed_commands(pipeline, offset, count, route)
+                .await
+        }
+        .boxed()
+    }
+
+    /// Sends a command into the TCP socket and reads the single response from it.
+    fn req_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
+        let routing = RoutingInfo::for_routable(cmd);
+        let cmd = cmd.pack_command_to_bytes();
+        self.send_packed_command(cmd, routing).boxed()
+    }
+
+    /// Sends multiple commands into the TCP socket, skips `offset` responses and reads `count` responses from it.
+    /// This is used to implement pipelining.
     fn req_pipeline<'a>(
         &'a mut self,
         pipeline: &'a crate::Pipeline,
         offset: usize,
         count: usize,
     ) -> RedisFuture<'a, Vec<Value>> {
-        let (sender, receiver) = oneshot::channel();
-        Box::pin(async move {
-            self.0
-                .send(Message {
-                    cmd: CmdArg::Pipeline {
-                        pipeline: Arc::new(pipeline.clone()), // TODO Remove this clone?
-                        offset,
-                        count,
-                        func: |mut conn, pipeline, offset, count| {
-                            Box::pin(async move {
-                                conn.req_pipeline(&pipeline, offset, count)
-                                    .await
-                                    .map(Response::Multiple)
-                            })
-                        },
-                        route: route_pipeline(pipeline),
-                    },
-                    sender,
-                })
-                .await
-                .map_err(|_| RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe)))?;
-
-            receiver
-                .await
-                .unwrap_or_else(|_| {
-                    Err(RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe)))
-                })
-                .map(|response| match response {
-                    Response::Multiple(values) => values,
-                    Response::Single(_) => unreachable!(),
-                })
-        })
+        let route = route_pipeline(pipeline.cmd_iter());
+        let pipeline = pipeline.get_packed_pipeline_as_bytes();
+        self.send_packed_commands(pipeline, offset, count, route)
+            .boxed()
     }
 
     fn get_db(&self) -> i64 {
@@ -1154,7 +1217,7 @@ mod pipeline_routing_tests {
             .add_command(cmd("EVAL")); // route randomly
 
         assert_eq!(
-            route_pipeline(&pipeline),
+            route_pipeline(pipeline.cmd_iter()),
             Some(Route::new(12182, SlotAddr::Replica))
         );
     }
@@ -1169,7 +1232,7 @@ mod pipeline_routing_tests {
             .get("foo"); // route to slot 12182
 
         assert_eq!(
-            route_pipeline(&pipeline),
+            route_pipeline(pipeline.cmd_iter()),
             Some(Route::new(4813, SlotAddr::Master))
         );
     }

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -21,7 +21,7 @@ pub(crate) enum Redirect {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub(crate) enum RoutingInfo {
+pub enum RoutingInfo {
     AllNodes,
     AllMasters,
     Random,
@@ -270,7 +270,7 @@ impl SlotMap {
 /// Defines the slot and the [`SlotAddr`] to which
 /// a command should be sent
 #[derive(Eq, PartialEq, Clone, Copy, Debug)]
-pub(crate) struct Route(u16, SlotAddr);
+pub struct Route(u16, SlotAddr);
 
 impl Route {
     pub(crate) fn new(slot: u16, slot_addr: SlotAddr) -> Self {

--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -662,6 +662,7 @@ where
     let mut bytes = BytesMut::with_capacity(length);
 
     pack_command_to_preallocated_bytes(args, &mut bytes, &mut num_to_string);
+    assert!(bytes.len() == length);
     bytes.freeze()
 }
 

--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -411,7 +411,7 @@ impl Cmd {
         write_command_to_vec(cmd, self.args_iter(), self.cursor.unwrap_or(0))
     }
 
-    pub(crate) fn write_packed_command_preallocated(&self, cmd: &mut Vec<u8>) {
+    pub(crate) fn write_packed_command_preallocated(&self, cmd: &mut impl BufMut) {
         write_command(cmd, self.args_iter(), self.cursor.unwrap_or(0))
     }
 

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -409,7 +409,10 @@ pub use crate::types::{
 #[cfg(feature = "aio")]
 #[cfg_attr(docsrs, doc(cfg(feature = "aio")))]
 pub use crate::{
-    cmd::AsyncIter, commands::AsyncCommands, parser::parse_redis_value_async, types::RedisFuture,
+    cmd::{pack_command_to_bytes, AsyncIter},
+    commands::AsyncCommands,
+    parser::parse_redis_value_async,
+    types::RedisFuture,
 };
 
 mod macros;

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -362,7 +362,7 @@ assert_eq!(result, Ok(("foo".to_string(), b"bar".to_vec())));
 
 // public api
 pub use crate::client::Client;
-pub use crate::cmd::{cmd, pack_command, pipe, Arg, Cmd, Iter};
+pub use crate::cmd::{args_len, cmd, pack_command, pipe, Arg, Cmd, Iter};
 pub use crate::commands::{
     Commands, ControlFlow, Direction, LposOptions, PubSubCommands, SetOptions,
 };
@@ -371,7 +371,7 @@ pub use crate::connection::{
     IntoConnectionInfo, Msg, PubSub, RedisConnectionInfo,
 };
 pub use crate::parser::{parse_redis_value, Parser};
-pub use crate::pipeline::Pipeline;
+pub use crate::pipeline::{packed_pipeline_length, Pipeline, EXEC_COMMAND, MULTI_COMMAND};
 
 #[cfg(feature = "script")]
 #[cfg_attr(docsrs, doc(cfg(feature = "script")))]
@@ -409,7 +409,7 @@ pub use crate::types::{
 #[cfg(feature = "aio")]
 #[cfg_attr(docsrs, doc(cfg(feature = "aio")))]
 pub use crate::{
-    cmd::{pack_command_to_bytes, AsyncIter},
+    cmd::{pack_command_to_bytes, pack_command_to_preallocated_bytes, AsyncIter},
     commands::AsyncCommands,
     parser::parse_redis_value_async,
     types::RedisFuture,

--- a/redis/src/parser.rs
+++ b/redis/src/parser.rs
@@ -169,7 +169,7 @@ where
 mod aio_support {
     use super::*;
 
-    use bytes::{Buf, BytesMut};
+    use bytes::{Buf, Bytes, BytesMut};
     use tokio::io::AsyncRead;
     use tokio_util::codec::{Decoder, Encoder};
 
@@ -212,9 +212,9 @@ mod aio_support {
         }
     }
 
-    impl Encoder<Vec<u8>> for ValueCodec {
+    impl Encoder<Bytes> for ValueCodec {
         type Error = RedisError;
-        fn encode(&mut self, item: Vec<u8>, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        fn encode(&mut self, item: Bytes, dst: &mut BytesMut) -> Result<(), Self::Error> {
             dst.extend_from_slice(item.as_ref());
             Ok(())
         }

--- a/redis/src/pipeline.rs
+++ b/redis/src/pipeline.rs
@@ -149,9 +149,7 @@ impl Pipeline {
     where
         C: crate::aio::ConnectionLike,
     {
-        let value = con
-            .req_packed_commands(self, 0, self.commands.len())
-            .await?;
+        let value = con.req_pipeline(self, 0, self.commands.len()).await?;
         Ok(self.make_pipeline_results(value))
     }
 
@@ -160,9 +158,7 @@ impl Pipeline {
     where
         C: crate::aio::ConnectionLike,
     {
-        let mut resp = con
-            .req_packed_commands(self, self.commands.len() + 1, 1)
-            .await?;
+        let mut resp = con.req_pipeline(self, self.commands.len() + 1, 1).await?;
         match resp.pop() {
             Some(Value::Nil) => Ok(Value::Nil),
             Some(Value::Bulk(items)) => Ok(self.make_pipeline_results(items)),

--- a/redis/tests/support/mock_cluster.rs
+++ b/redis/tests/support/mock_cluster.rs
@@ -205,24 +205,24 @@ pub fn respond_startup_with_replica_using_config(
 
 #[cfg(feature = "cluster-async")]
 impl aio::ConnectionLike for MockConnection {
-    fn req_command<'a>(&'a mut self, cmd: &'a redis::Cmd) -> RedisFuture<'a, Value> {
+    fn get_db(&self) -> i64 {
+        0
+    }
+
+    fn req_packed_command(&mut self, cmd: bytes::Bytes) -> RedisFuture<Value> {
         Box::pin(future::ready(
-            (self.handler)(&cmd.get_packed_command(), self.port)
+            (self.handler)(cmd.as_ref(), self.port)
                 .expect_err("Handler did not specify a response"),
         ))
     }
 
-    fn req_pipeline<'a>(
-        &'a mut self,
-        _pipeline: &'a redis::Pipeline,
+    fn req_packed_commands(
+        &mut self,
+        _cmd: bytes::Bytes,
         _offset: usize,
         _count: usize,
-    ) -> RedisFuture<'a, Vec<Value>> {
-        Box::pin(future::ok(vec![]))
-    }
-
-    fn get_db(&self) -> i64 {
-        0
+    ) -> RedisFuture<Vec<Value>> {
+        todo!()
     }
 }
 

--- a/redis/tests/support/mock_cluster.rs
+++ b/redis/tests/support/mock_cluster.rs
@@ -205,14 +205,14 @@ pub fn respond_startup_with_replica_using_config(
 
 #[cfg(feature = "cluster-async")]
 impl aio::ConnectionLike for MockConnection {
-    fn req_packed_command<'a>(&'a mut self, cmd: &'a redis::Cmd) -> RedisFuture<'a, Value> {
+    fn req_command<'a>(&'a mut self, cmd: &'a redis::Cmd) -> RedisFuture<'a, Value> {
         Box::pin(future::ready(
             (self.handler)(&cmd.get_packed_command(), self.port)
                 .expect_err("Handler did not specify a response"),
         ))
     }
 
-    fn req_packed_commands<'a>(
+    fn req_pipeline<'a>(
         &'a mut self,
         _pipeline: &'a redis::Pipeline,
         _offset: usize,

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -472,7 +472,7 @@ fn test_async_cluster_ask_redirect() {
                     },
                     6380 => match count {
                         1 => {
-                            assert!(contains_slice(cmd, b"ASKING"));
+                            assert!(contains_slice(cmd, b"*1\r\n$6\r\nASKING\r\n"));
                             Err(Ok(Value::Okay))
                         }
                         2 => {

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -233,21 +233,21 @@ impl Connect for ErrorConnection {
 }
 
 impl ConnectionLike for ErrorConnection {
-    fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
+    fn req_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
         if ERROR.load(Ordering::SeqCst) {
             Box::pin(async move { Err(RedisError::from((redis::ErrorKind::Moved, "ERROR"))) })
         } else {
-            self.inner.req_packed_command(cmd)
+            self.inner.req_command(cmd)
         }
     }
 
-    fn req_packed_commands<'a>(
+    fn req_pipeline<'a>(
         &'a mut self,
         pipeline: &'a redis::Pipeline,
         offset: usize,
         count: usize,
     ) -> RedisFuture<'a, Vec<Value>> {
-        self.inner.req_packed_commands(pipeline, offset, count)
+        self.inner.req_pipeline(pipeline, offset, count)
     }
 
     fn get_db(&self) -> i64 {


### PR DESCRIPTION
This saves us from using `Cmd` objects, which require multiple allocations.