### PR TITLE
Added management connections to be used with the periodic checks

### DIFF
--- a/redis/src/cluster_async/connections_container.rs
+++ b/redis/src/cluster_async/connections_container.rs
@@ -37,6 +37,7 @@ where
             ConnectionType::User => self.user_connection.clone(),
             ConnectionType::PreferManagement => self
                 .management_connection
+                .clone()
                 .unwrap_or_else(|| self.user_connection.clone()),
         }
     }
@@ -631,7 +632,7 @@ mod tests {
     fn get_random_management_connections() {
         let container = create_container_with_strategy(ReadFromReplicaStrategy::RoundRobin);
         let mut random_connections: Vec<_> = container
-            .random_connections(1000, ConnectionType::Management)
+            .random_connections(1000, ConnectionType::PreferManagement)
             .map(|pair| pair.1)
             .collect();
         random_connections.sort();

--- a/redis/src/cluster_async/connections_container.rs
+++ b/redis/src/cluster_async/connections_container.rs
@@ -35,7 +35,7 @@ where
     pub(crate) fn get_connection(&self, conn_type: &ConnectionType) -> Connection {
         match conn_type {
             ConnectionType::User => self.user_connection.clone(),
-            ConnectionType::_Management => self
+            ConnectionType::Management => self
                 .management_connection
                 .clone()
                 .unwrap_or_else(|| self.user_connection.clone()),
@@ -47,7 +47,7 @@ where
 
 pub(crate) enum ConnectionType {
     User,
-    _Management,
+    Management,
 }
 
 /// This opaque type allows us to change the way that the connections are organized
@@ -678,7 +678,7 @@ mod tests {
     fn get_random_management_connections() {
         let container = create_container_with_strategy(ReadFromReplicaStrategy::RoundRobin, true);
         let mut random_connections: Vec<_> = container
-            .random_connections(1000, ConnectionType::_Management)
+            .random_connections(1000, ConnectionType::Management)
             .map(|pair| pair.1)
             .collect();
         random_connections.sort();

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -117,10 +117,6 @@ impl ClusterParams {
             protocol: value.protocol,
         })
     }
-
-    pub(crate) fn management_connections_enabled(&self) -> bool {
-        self.topology_checks_interval.is_some()
-    }
 }
 
 /// Used to configure and build a [`ClusterClient`].

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -117,6 +117,10 @@ impl ClusterParams {
             protocol: value.protocol,
         })
     }
+
+    pub(crate) fn management_connections_enabled(&self) -> bool {
+        self.topology_checks_interval.is_some()
+    }
 }
 
 /// Used to configure and build a [`ClusterClient`].

--- a/redis/src/cluster_topology.rs
+++ b/redis/src/cluster_topology.rs
@@ -16,6 +16,8 @@ pub const DEFAULT_NUMBER_OF_REFRESH_SLOTS_RETRIES: usize = 3;
 pub const DEFAULT_REFRESH_SLOTS_RETRY_TIMEOUT: Duration = Duration::from_secs(1);
 /// The default initial interval for retrying topology refresh
 pub const DEFAULT_REFRESH_SLOTS_RETRY_INITIAL_INTERVAL: Duration = Duration::from_millis(100);
+/// The client's management connections name
+pub const MANAGEMENT_CONN_NAME: &str = "babushka_management_connection";
 
 pub(crate) const SLOT_SIZE: u16 = 16384;
 pub(crate) type TopologyHash = u64;

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -131,7 +131,6 @@ pub enum ErrorKind {
     EmptySentinelList,
     /// Attempted to kill a script/function while they werent' executing
     NotBusy,
-
     #[cfg(feature = "json")]
     /// Error Serializing a struct to JSON form
     Serialize,
@@ -139,6 +138,8 @@ pub enum ErrorKind {
     /// Redis Servers prior to v6.0.0 doesn't support RESP3.
     /// Try disabling resp3 option
     RESP3NotSupported,
+    /// The management connection isn't set
+    NoneManagementConn,
 }
 
 /// Internal low-level redis value enum.
@@ -624,6 +625,7 @@ impl RedisError {
             #[cfg(feature = "json")]
             ErrorKind::Serialize => "serializing",
             ErrorKind::RESP3NotSupported => "resp3 is not supported by server",
+            ErrorKind::NoneManagementConn => "the management connection isn't set",
         }
     }
 
@@ -776,6 +778,7 @@ impl RedisError {
             #[cfg(feature = "json")]
             ErrorKind::Serialize => false,
             ErrorKind::RESP3NotSupported => false,
+            ErrorKind::NoneManagementConn => false,
         }
     }
 }

--- a/redis/tests/support/mock_cluster.rs
+++ b/redis/tests/support/mock_cluster.rs
@@ -114,7 +114,7 @@ pub fn contains_slice(xs: &[u8], ys: &[u8]) -> bool {
 }
 
 pub fn respond_startup(name: &str, cmd: &[u8]) -> Result<(), RedisResult<Value>> {
-    if contains_slice(cmd, b"PING") {
+    if contains_slice(cmd, b"PING") || contains_slice(cmd, b"SETNAME") {
         Err(Ok(Value::SimpleString("OK".into())))
     } else if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
         Err(Ok(Value::Array(vec![Value::Array(vec![
@@ -203,7 +203,7 @@ pub fn respond_startup_with_replica_using_config(
             slot_range: (8192..16383),
         },
     ]);
-    if contains_slice(cmd, b"PING") {
+    if contains_slice(cmd, b"PING") || contains_slice(cmd, b"SETNAME") {
         Err(Ok(Value::SimpleString("OK".into())))
     } else if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
         let slots = create_topology_from_config(name, slots_config);


### PR DESCRIPTION
This PR adds another connection (called 'management connection') for each cluster node so they could be used in the periodic checks, if the periodic checks is enabled.

Rebased over #64 , #90

Benchmark results:
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/barshaul/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/barshaul/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{mso-number-format:"0\.000";}
.xl66
	{mso-number-format:Percent;}
.xl67
	{border:.5pt solid windowtext;}
.xl68
	{mso-number-format:"0\.000";
	border:.5pt solid windowtext;}
.xl69
	{mso-number-format:Percent;
	border:.5pt solid windowtext;}
.xl70
	{font-weight:700;
	border:.5pt solid windowtext;}
.xl71
	{font-weight:700;
	mso-number-format:"0\.000";
	border:.5pt solid windowtext;}
.xl72
	{font-weight:700;
	mso-number-format:Percent;
	border:.5pt solid windowtext;}
.xl73
	{color:red;
	mso-number-format:Percent;
	border:.5pt solid windowtext;}
.xl74
	{color:#548235;
	mso-number-format:Percent;
	border:.5pt solid windowtext;}
.xl75
	{vertical-align:middle;
	border-top:.5pt solid windowtext;
	border-right:.5pt solid windowtext;
	border-bottom:none;
	border-left:.5pt solid windowtext;}
.xl76
	{font-weight:700;
	mso-number-format:0;
	border:.5pt solid windowtext;}
.xl77
	{mso-number-format:0;
	border:.5pt solid windowtext;}
.xl78
	{mso-number-format:0;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">



test | num_of_tasks | data_size | Average of tps | get non   existing average latency | get existing   average latency | set average   latency | TPS diff
-- | -- | -- | -- | -- | -- | -- | --
python_baseline | 1 | 100 | 939 | 0.001 | 0.001 | 0.001 |  
python_baseline |   | 4000 | 921 | 0.001 | 0.001 | 0.001 |  
python_baseline | 10 | 100 | 6556 | 0.002 | 0.002 | 0.002 |  
python_baseline |   | 4000 | 6321 | 0.002 | 0.002 | 0.002 |  
python_baseline | 100 | 100 | 26655 | 0.004 | 0.004 | 0.004 |  
python_baseline |   | 4000 | 22485 | 0.004 | 0.004 | 0.004 |  
python_baseline | 1000 | 100 | 28057 | 0.036 | 0.035 | 0.036 |  
python_baseline |   | 4000 | 24573 | 0.041 | 0.042 | 0.041 |  
python_mange_conn_120_sec | 1 | 100 | 937 | 0.001 | 0.001 | 0.001 | 99.83%
python_mange_conn_120_sec |   | 4000 | 937 | 0.001 | 0.001 | 0.001 | 101.78%
python_mange_conn_120_sec | 10 | 100 | 6491 | 0.002 | 0.002 | 0.002 | 99.01%
python_mange_conn_120_sec |   | 4000 | 6400 | 0.002 | 0.002 | 0.002 | 101.26%
python_mange_conn_120_sec | 100 | 100 | 25537 | 0.004 | 0.004 | 0.004 | 95.81%
python_mange_conn_120_sec |   | 4000 | 22479 | 0.004 | 0.004 | 0.004 | 99.97%
python_mange_conn_120_sec | 1000 | 100 | 26967 | 0.037 | 0.038 | 0.037 | 96.12%
python_mange_conn_120_sec |   | 4000 | 25546 | 0.038 | 0.040 | 0.037 | 103.96%
python_mang_conn_60_sec | 1 | 100 | 951 | 0.001 | 0.001 | 0.001 | 101.30%
python_mang_conn_60_sec |   | 4000 | 927 | 0.001 | 0.001 | 0.001 | 100.60%
python_mang_conn_60_sec | 10 | 100 | 6374 | 0.002 | 0.002 | 0.002 | 97.22%
python_mang_conn_60_sec |   | 4000 | 6437 | 0.002 | 0.002 | 0.002 | 101.84%
python_mang_conn_60_sec | 100 | 100 | 26341 | 0.004 | 0.004 | 0.004 | 98.82%
python_mang_conn_60_sec |   | 4000 | 22788 | 0.004 | 0.004 | 0.004 | 101.35%
python_mang_conn_60_sec | 1000 | 100 | 26090 | 0.038 | 0.036 | 0.039 | 92.99%
python_mang_conn_60_sec |   | 4000 | 25010 | 0.040 | 0.040 | 0.040 | 101.78%
Average TPS diff |   |   |   |   |   |   | 99.60%



</body>

</html>
