### PR TITLE
Increased default refresh slots retry interval

### DIFF
--- a/redis/src/cluster_topology.rs
+++ b/redis/src/cluster_topology.rs
@@ -15,7 +15,7 @@ pub const DEFAULT_NUMBER_OF_REFRESH_SLOTS_RETRIES: usize = 3;
 /// The default timeout for retrying topology refresh
 pub const DEFAULT_REFRESH_SLOTS_RETRY_TIMEOUT: Duration = Duration::from_secs(1);
 /// The default initial interval for retrying topology refresh
-pub const DEFAULT_REFRESH_SLOTS_RETRY_INITIAL_INTERVAL: Duration = Duration::from_millis(100);
+pub const DEFAULT_REFRESH_SLOTS_RETRY_INITIAL_INTERVAL: Duration = Duration::from_millis(500);
 
 pub(crate) const SLOT_SIZE: u16 = 16384;
 pub(crate) type TopologyHash = u64;


### PR DESCRIPTION
Increased default refresh slots retry interval to reduce chances for connection storms.
Related issue: https://github.com/aws/babushka/issues/532