### PR TITLE
Prefer routing to primary in a transaction.

### DIFF
--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -245,7 +245,7 @@ enum CmdArg<C> {
     },
 }
 
-fn route_pipeline(pipeline: &crate::Pipeline) -> Option<Route> {
+fn route_for_pipeline(pipeline: &crate::Pipeline) -> Option<Route> {
     let route_for_command = |cmd| -> Option<Route> {
         match RoutingInfo::for_routable(cmd) {
             Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random)) => None,
@@ -1489,7 +1489,7 @@ where
         offset: usize,
         count: usize,
     ) -> RedisFuture<'a, Vec<Value>> {
-        let route = route_pipeline(pipeline).into();
+        let route = route_for_pipeline(pipeline).into();
         self.route_pipeline(pipeline, offset, count, route).boxed()
     }
 
@@ -1588,7 +1588,7 @@ fn get_host_and_port_from_addr(addr: &str) -> Option<(&str, u16)> {
 
 #[cfg(test)]
 mod pipeline_routing_tests {
-    use super::route_pipeline;
+    use super::route_for_pipeline;
     use crate::{
         cluster_routing::{Route, SlotAddr},
         cmd,
@@ -1604,7 +1604,7 @@ mod pipeline_routing_tests {
             .add_command(cmd("EVAL")); // route randomly
 
         assert_eq!(
-            route_pipeline(&pipeline),
+            route_for_pipeline(&pipeline),
             Some(Route::new(12182, SlotAddr::ReplicaOptional))
         );
     }
@@ -1619,7 +1619,7 @@ mod pipeline_routing_tests {
             .get("foo"); // route to slot 12182
 
         assert_eq!(
-            route_pipeline(&pipeline),
+            route_for_pipeline(&pipeline),
             Some(Route::new(4813, SlotAddr::Master))
         );
     }

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -245,8 +245,8 @@ enum CmdArg<C> {
     },
 }
 
-fn route_for_pipeline(pipeline: &crate::Pipeline) -> Option<Route> {
-    let route_for_command = |cmd| -> Option<Route> {
+fn route_for_pipeline(pipeline: &crate::Pipeline) -> RedisResult<Option<Route>> {
+    fn route_for_command(cmd: &Cmd) -> Option<Route> {
         match RoutingInfo::for_routable(cmd) {
             Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random)) => None,
             Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(route))) => {
@@ -255,28 +255,26 @@ fn route_for_pipeline(pipeline: &crate::Pipeline) -> Option<Route> {
             Some(RoutingInfo::MultiNode(_)) => None,
             None => None,
         }
-    };
+    }
 
     // Find first specific slot and send to it. There's no need to check If later commands
     // should be routed to a different slot, since the server will return an error indicating this.
-    pipeline
-        .cmd_iter()
-        .map(route_for_command)
-        .fold(None, |chosen_route, next_cmd_route| {
-            match (chosen_route, next_cmd_route) {
-                (None, _) => next_cmd_route,
-                (Some(route), None) => Some(route),
-                (Some(chosen_route), Some(next_cmd_route)) => {
-                    if chosen_route.slot() == next_cmd_route.slot()
-                        && chosen_route.slot_addr() == SlotAddr::ReplicaOptional
-                    {
-                        Some(next_cmd_route)
-                    } else {
-                        Some(chosen_route)
-                    }
+    pipeline.cmd_iter().map(route_for_command).try_fold(
+        None,
+        |chosen_route, next_cmd_route| match (chosen_route, next_cmd_route) {
+            (None, _) => Ok(next_cmd_route),
+            (_, None) => Ok(chosen_route),
+            (Some(chosen_route), Some(next_cmd_route)) => {
+                if chosen_route.slot() != next_cmd_route.slot() {
+                    Err((ErrorKind::CrossSlot, "Received crossed slots in pipeline").into())
+                } else if chosen_route.slot_addr() == SlotAddr::ReplicaOptional {
+                    Ok(Some(next_cmd_route))
+                } else {
+                    Ok(Some(chosen_route))
                 }
             }
-        })
+        },
+    )
 }
 enum Response {
     Single(Value),
@@ -1502,8 +1500,12 @@ where
         offset: usize,
         count: usize,
     ) -> RedisFuture<'a, Vec<Value>> {
-        let route = route_for_pipeline(pipeline).into();
-        self.route_pipeline(pipeline, offset, count, route).boxed()
+        async move {
+            let route = route_for_pipeline(pipeline)?;
+            self.route_pipeline(pipeline, offset, count, route.into())
+                .await
+        }
+        .boxed()
     }
 
     fn get_db(&self) -> i64 {
@@ -1618,8 +1620,19 @@ mod pipeline_routing_tests {
 
         assert_eq!(
             route_for_pipeline(&pipeline),
-            Some(Route::new(12182, SlotAddr::ReplicaOptional))
+            Ok(Some(Route::new(12182, SlotAddr::ReplicaOptional)))
         );
+    }
+
+    #[test]
+    fn test_return_none_if_no_route_is_found() {
+        let mut pipeline = crate::Pipeline::new();
+
+        pipeline
+            .add_command(cmd("FLUSHALL")) // route to all masters
+            .add_command(cmd("EVAL")); // route randomly
+
+        assert_eq!(route_for_pipeline(&pipeline), Ok(None));
     }
 
     #[test]
@@ -1634,12 +1647,12 @@ mod pipeline_routing_tests {
 
         assert_eq!(
             route_for_pipeline(&pipeline),
-            Some(Route::new(12182, SlotAddr::Master))
+            Ok(Some(Route::new(12182, SlotAddr::Master)))
         );
     }
 
     #[test]
-    fn test_ignore_conflicting_slots() {
+    fn test_raise_cross_slot_error_on_conflicting_slots() {
         let mut pipeline = crate::Pipeline::new();
 
         pipeline
@@ -1648,8 +1661,8 @@ mod pipeline_routing_tests {
             .get("foo"); // route to slot 12182
 
         assert_eq!(
-            route_for_pipeline(&pipeline),
-            Some(Route::new(4813, SlotAddr::Master))
+            route_for_pipeline(&pipeline).unwrap_err().kind(),
+            crate::ErrorKind::CrossSlot
         );
     }
 }


### PR DESCRIPTION
This change will cause transactions with commands that are routed to replicas and primaries to prefer the primary routing over the replica.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
