### PR TITLE
Add support for client name configuration

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -137,6 +137,7 @@ tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "time"] 
 tempfile = "=3.6.0"
 once_cell = "1"
 anyhow = "1"
+sscanf = "0.4.1"
 
 [[test]]
 name = "test_async"

--- a/redis/src/aio/mod.rs
+++ b/redis/src/aio/mod.rs
@@ -140,6 +140,21 @@ where
         }
     }
 
+    if let Some(client_name) = &connection_info.client_name {
+        match cmd("CLIENT")
+            .arg("SETNAME")
+            .arg(client_name)
+            .query_async(con)
+            .await
+        {
+            Ok(Value::Okay) => {}
+            _ => fail!((
+                ErrorKind::ResponseError,
+                "Redis server refused to set client name"
+            )),
+        }
+    }
+
     // result is ignored, as per the command's instructions.
     // https://redis.io/commands/client-setinfo/
     let _: RedisResult<()> = crate::connection::client_set_info_pipeline()

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -910,6 +910,7 @@ pub(crate) fn get_connection_info(
         redis: RedisConnectionInfo {
             password: cluster_params.password,
             username: cluster_params.username,
+            client_name: cluster_params.client_name,
             use_resp3: cluster_params.use_resp3,
             ..Default::default()
         },

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -59,6 +59,7 @@
 //!                 username: Some(String::from("foo")),
 //!                 password: Some(String::from("bar")),
 //!                 use_resp3: false,
+//!                 client_name: None
 //!             }),
 //!         }),
 //!     )
@@ -95,6 +96,7 @@
 //!             username: Some(String::from("user")),
 //!             password: Some(String::from("pass")),
 //!             use_resp3: false,
+//!             client_name: None
 //!         }),
 //!     }),
 //!     redis::sentinel::SentinelServerType::Master,

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -74,6 +74,10 @@ impl RedisCluster {
         "world"
     }
 
+    pub fn client_name() -> &'static str {
+        "test_cluster_client"
+    }
+
     pub fn new(nodes: u16, replicas: u16) -> RedisCluster {
         RedisCluster::with_modules(nodes, replicas, &[], false)
     }

--- a/redis/tests/support/util.rs
+++ b/redis/tests/support/util.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 #[macro_export]
 macro_rules! assert_args {
     ($value:expr, $($args:expr),+) => {
@@ -7,4 +9,15 @@ macro_rules! assert_args {
                                 .collect();
         assert_eq!(strings, vec![$($args),+]);
     }
+}
+
+pub fn parse_client_info(client_info: &str) -> HashMap<String, String> {
+    let mut res = HashMap::new();
+
+    for line in client_info.split(' ') {
+        let this_attr: Vec<&str> = line.split('=').collect();
+        res.insert(this_attr[0].to_string(), this_attr[1].to_string());
+    }
+
+    res
 }

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -1448,3 +1448,26 @@ fn test_blocking_sorted_set_api() {
         );
     }
 }
+
+#[test]
+fn test_set_client_name_by_config() {
+    const CLIENT_NAME: &str = "TEST_CLIENT_NAME";
+
+    let ctx = TestContext::with_client_name(CLIENT_NAME);
+    let mut con = ctx.connection();
+
+    let client_info: String = redis::cmd("CLIENT").arg("INFO").query(&mut con).unwrap();
+
+    let client_attrs = parse_client_info(&client_info);
+
+    assert!(
+        client_attrs.contains_key("name"),
+        "Could not detect the 'name' attribute in CLIENT INFO output"
+    );
+
+    assert_eq!(
+        client_attrs["name"], CLIENT_NAME,
+        "Incorrect client name, expecting: {}, got {}",
+        CLIENT_NAME, client_attrs["name"]
+    );
+}

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -887,6 +887,33 @@ fn test_cluster_route_correctly_on_packed_transaction_with_single_node_requests2
     assert_eq!(result, expected_result);
 }
 
+#[test]
+fn test_cluster_with_client_name() {
+    let cluster = TestClusterContext::new_with_cluster_client_builder(
+        3,
+        0,
+        |builder| builder.client_name(RedisCluster::client_name().to_string()),
+        false,
+    );
+    let mut con = cluster.connection();
+    let client_info: String = redis::cmd("CLIENT").arg("INFO").query(&mut con).unwrap();
+
+    let client_attrs = parse_client_info(&client_info);
+
+    assert!(
+        client_attrs.contains_key("name"),
+        "Could not detect the 'name' attribute in CLIENT INFO output"
+    );
+
+    assert_eq!(
+        client_attrs["name"],
+        RedisCluster::client_name(),
+        "Incorrect client name, expecting: {}, got {}",
+        RedisCluster::client_name(),
+        client_attrs["name"]
+    );
+}
+
 #[cfg(feature = "tls-rustls")]
 mod mtls_test {
     use super::*;


### PR DESCRIPTION

*Issue #, if available:*
Part of https://github.com/aws/babushka/issues/407

*Description of changes:*
Add optional client_name property to RedisConnectionInfo, which will be used with 'CLIENT SETNAME' command during connection setup.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
