### PR TITLE
Remove allocation from `command` function.

### DIFF
--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -554,12 +554,14 @@ pub trait Routable {
             }
         };
 
-        let secondary_command = self.arg_idx(1).map(|x| x.to_ascii_uppercase());
-        Some(match secondary_command {
-            Some(cmd) => {
-                primary_command.reserve(cmd.len() + 1);
+        Some(match self.arg_idx(1) {
+            Some(secondary_command) => {
+                let previous_len = primary_command.len();
+                primary_command.reserve(secondary_command.len() + 1);
                 primary_command.extend(b" ");
-                primary_command.extend(cmd);
+                primary_command.extend(secondary_command);
+                let current_len = primary_command.len();
+                primary_command[previous_len + 1..current_len].make_ascii_uppercase();
                 primary_command
             }
             None => primary_command,


### PR DESCRIPTION
Instead of allocating the ASCII uppercase conversion of `self.arg_idx(1)` and then copying it into the target vec, we copy the slice, and then convert it to uppercase in-place. This saves the allocation of the vec, which is only used for copying.

The perf difference here is too small to be conclusive in benchmarks, but the reduction in the generated assembly is noticable (~920 lines of assembly to ~800) - https://godbolt.org/z/7srEv8vra

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
