### PR TITLE
Fix multi-slot routes/addresses mismatch.

### DIFF
--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -36,6 +36,7 @@
 //!     .query(&mut connection).unwrap();
 //! ```
 use std::cell::RefCell;
+use std::collections::HashSet;
 use std::iter::Iterator;
 use std::str::FromStr;
 use std::thread;
@@ -484,6 +485,81 @@ where
         Ok(result)
     }
 
+    fn exectue_on_all<'a>(
+        &'a self,
+        input: Input,
+        addresses: HashSet<&'a str>,
+        connections: &'a mut HashMap<String, C>,
+    ) -> Vec<RedisResult<(&'a str, Value)>> {
+        addresses
+            .into_iter()
+            .map(|addr| {
+                let connection = self.get_connection_by_addr(connections, addr)?;
+                match input {
+                    Input::Slice { cmd, routable: _ } => connection.req_packed_command(cmd),
+                    Input::Cmd(cmd) => connection.req_command(cmd),
+                    Input::Commands {
+                        cmd: _,
+                        route: _,
+                        offset: _,
+                        count: _,
+                    } => Err((
+                        ErrorKind::ClientError,
+                        "req_packed_commands isn't supported with multiple nodes",
+                    )
+                        .into()),
+                }
+                .map(|res| (addr, res))
+            })
+            .collect()
+    }
+
+    fn exectue_on_all_nodes<'a>(
+        &'a self,
+        input: Input,
+        slots: &'a mut SlotMap,
+        connections: &'a mut HashMap<String, C>,
+    ) -> Vec<RedisResult<(&'a str, Value)>> {
+        self.exectue_on_all(input, slots.addresses_for_all_nodes(), connections)
+    }
+
+    fn exectue_on_all_primaries<'a>(
+        &'a self,
+        input: Input,
+        slots: &'a mut SlotMap,
+        connections: &'a mut HashMap<String, C>,
+    ) -> Vec<RedisResult<(&'a str, Value)>> {
+        self.exectue_on_all(input, slots.addresses_for_all_primaries(), connections)
+    }
+
+    fn exectue_multi_slot<'a, 'b>(
+        &'a self,
+        input: Input,
+        slots: &'a mut SlotMap,
+        connections: &'a mut HashMap<String, C>,
+        routes: &'b [(Route, Vec<usize>)],
+    ) -> Vec<RedisResult<(&'a str, Value)>>
+    where
+        'b: 'a,
+    {
+        slots
+            .addresses_for_multi_slot(routes)
+            .enumerate()
+            .map(|(index, addr)| {
+                let addr = addr.ok_or(RedisError::from((
+                    ErrorKind::IoError,
+                    "Couldn't find connection",
+                    format!("For route {:?}", routes.get(index)),
+                )))?;
+                let connection = self.get_connection_by_addr(connections, addr)?;
+                let (_, indices) = routes.get(index).unwrap();
+                let cmd =
+                    crate::cluster_routing::command_for_multi_slot_indices(&input, indices.iter());
+                connection.req_command(&cmd).map(|res| (addr, res))
+            })
+            .collect()
+    }
+
     fn execute_on_multiple_nodes(
         &self,
         input: Input,
@@ -491,45 +567,20 @@ where
         response_policy: Option<ResponsePolicy>,
     ) -> RedisResult<Value> {
         let mut connections = self.connections.borrow_mut();
-        let slots = self.slots.borrow_mut();
-        let addresses = slots.addresses_for_multi_routing(&routing);
+        let mut slots = self.slots.borrow_mut();
 
-        // TODO: reconnect and shit
-        let results = addresses.iter().enumerate().map(|(index, addr)| {
-            if let Some(connection) = connections.get_mut(*addr) {
-                match &routing {
-                    MultipleNodeRoutingInfo::MultiSlot(vec) => {
-                        let (_, indices) = vec.get(index).unwrap();
-                        let cmd = crate::cluster_routing::command_for_multi_slot_indices(
-                            &input,
-                            indices.iter(),
-                        );
-                        connection.req_command(&cmd)
-                    }
-                    _ => match input {
-                        Input::Slice { cmd, routable: _ } => connection.req_packed_command(cmd),
-                        Input::Cmd(cmd) => connection.req_command(cmd),
-                        Input::Commands {
-                            cmd: _,
-                            route: _,
-                            offset: _,
-                            count: _,
-                        } => Err((
-                            ErrorKind::ClientError,
-                            "req_packed_commands isn't supported with multiple nodes",
-                        )
-                            .into()),
-                    },
-                }
-            } else {
-                Err((
-                    ErrorKind::IoError,
-                    "connection error",
-                    format!("Disconnected from {addr}"),
-                )
-                    .into())
+        let results = match &routing {
+            MultipleNodeRoutingInfo::MultiSlot(routes) => {
+                self.exectue_multi_slot(input, &mut slots, &mut connections, routes)
             }
-        });
+            MultipleNodeRoutingInfo::AllMasters => {
+                self.exectue_on_all_primaries(input, &mut slots, &mut connections)
+            }
+            MultipleNodeRoutingInfo::AllNodes => {
+                self.exectue_on_all_nodes(input, &mut slots, &mut connections)
+            }
+        };
+
         match response_policy {
             Some(ResponsePolicy::AllSucceeded) => {
                 for result in results {
@@ -543,7 +594,7 @@ where
 
                 for result in results {
                     match result {
-                        Ok(val) => return Ok(val),
+                        Ok((_, val)) => return Ok(val),
                         Err(err) => last_failure = Some(err),
                     }
                 }
@@ -555,7 +606,7 @@ where
                 let mut last_failure = None;
 
                 for result in results {
-                    match result {
+                    match result.map(|(_, res)| res) {
                         Ok(Value::Nil) => continue,
                         Ok(val) => return Ok(val),
                         Err(err) => last_failure = Some(err),
@@ -565,15 +616,24 @@ where
                     .unwrap_or_else(|| (ErrorKind::IoError, "Couldn't find a connection").into()))
             }
             Some(ResponsePolicy::Aggregate(op)) => {
-                let results = results.collect::<RedisResult<Vec<_>>>()?;
+                let results = results
+                    .into_iter()
+                    .map(|res| res.map(|(_, val)| val))
+                    .collect::<RedisResult<Vec<_>>>()?;
                 crate::cluster_routing::aggregate(results, op)
             }
             Some(ResponsePolicy::AggregateLogical(op)) => {
-                let results = results.collect::<RedisResult<Vec<_>>>()?;
+                let results = results
+                    .into_iter()
+                    .map(|res| res.map(|(_, val)| val))
+                    .collect::<RedisResult<Vec<_>>>()?;
                 crate::cluster_routing::logical_aggregate(results, op)
             }
             Some(ResponsePolicy::CombineArrays) => {
-                let results = results.collect::<RedisResult<Vec<_>>>()?;
+                let results = results
+                    .into_iter()
+                    .map(|res| res.map(|(_, val)| val))
+                    .collect::<RedisResult<Vec<_>>>()?;
                 match routing {
                     MultipleNodeRoutingInfo::MultiSlot(vec) => {
                         crate::cluster_routing::combine_and_sort_array_results(
@@ -588,10 +648,9 @@ where
                 // This is our assumption - if there's no coherent way to aggregate the responses, we just map each response to the sender, and pass it to the user.
                 // TODO - once Value::Error is merged, we can use join_all and report separate errors and also pass successes.
                 let results = results
-                    .enumerate()
-                    .map(|(index, result)| {
-                        let addr = addresses[index];
-                        result.map(|val| (Value::BulkString(addr.as_bytes().to_vec()), val))
+                    .into_iter()
+                    .map(|result| {
+                        result.map(|(addr, val)| (Value::BulkString(addr.as_bytes().to_vec()), val))
                     })
                     .collect::<RedisResult<Vec<_>>>()?;
                 Ok(Value::Map(results))

--- a/redis/src/cluster_async/connections_container.rs
+++ b/redis/src/cluster_async/connections_container.rs
@@ -4,7 +4,7 @@ use std::net::IpAddr;
 use arcstr::ArcStr;
 use rand::seq::IteratorRandom;
 
-use crate::cluster_routing::{MultipleNodeRoutingInfo, Route, SlotAddr};
+use crate::cluster_routing::{Route, SlotAddr};
 use crate::cluster_topology::{ReadFromReplicaStrategy, SlotMap, SlotMapValue, TopologyHash};
 
 type IdentifierType = ArcStr;
@@ -160,7 +160,7 @@ where
         &self,
     ) -> impl Iterator<Item = ConnectionAndIdentifier<Connection>> + '_ {
         self.slot_map
-            .addresses_for_multi_routing(&MultipleNodeRoutingInfo::AllMasters) // TODO - this involves allocating a hash set and a vec. can this be avoided?
+            .addresses_for_all_primaries()
             .into_iter()
             .flat_map(|addr| self.connection_for_address(addr))
     }

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -986,6 +986,7 @@ where
                 &connections_container,
             ),
             MultipleNodeRoutingInfo::MultiSlot(slots) => into_channels(
+                // TODO - this filter_map means that missing addresses are silently ignored.
                 slots.iter().filter_map(|(route, indices)| {
                     connections_container
                         .connection_for_route(route)

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -88,10 +88,13 @@ pub enum MultipleNodeRoutingInfo {
 
 /// Takes a routable and an iterator of indices, which is assued to be created from`MultipleNodeRoutingInfo::MultiSlot`,
 /// and returns a command with the arguments matching the indices.
-pub fn command_for_multi_slot_indices<'a>(
+pub fn command_for_multi_slot_indices<'a, 'b>(
     original_cmd: &'a impl Routable,
-    indices: impl Iterator<Item = &'a usize> + 'a,
-) -> Cmd {
+    indices: impl Iterator<Item = &'b usize> + 'a,
+) -> Cmd
+where
+    'b: 'a,
+{
     let mut new_cmd = Cmd::new();
     let command_length = 1; // TODO - the +1 should change if we have multi-slot commands with 2 command words.
     new_cmd.arg(original_cmd.arg_idx(0));


### PR DESCRIPTION
If the `SlotMap` is partial, and some slots don't have addresses, then we need to communicate this back when getting addresses for multi-slot commands. Otherwise we the key indices won't match the addresses, and commands with the wrong keys will be sent to the wrong nodes.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
