### PR TITLE
Use enum instead of boolean for RESP version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test:
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with all features and RESP3"
 	@echo "===================================================================="
-	@REDISRS_SERVER_TYPE=tcp RESP3=true cargo test -p redis --all-features -- --nocapture --test-threads=1  --skip test_module
+	@REDISRS_SERVER_TYPE=tcp PROTOCOL=RESP3 cargo test -p redis --all-features -- --nocapture --test-threads=1  --skip test_module
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with all features and Rustls support"

--- a/redis/src/aio/connection.rs
+++ b/redis/src/aio/connection.rs
@@ -10,7 +10,7 @@ use crate::connection::{
 #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
 use crate::parser::ValueCodec;
 use crate::types::{ErrorKind, FromRedisValue, RedisError, RedisFuture, RedisResult, Value};
-use crate::{from_redis_value, ToRedisArgs};
+use crate::{from_redis_value, ProtocolVersion, ToRedisArgs};
 #[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
 use ::async_std::net::ToSocketAddrs;
 use ::tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
@@ -40,8 +40,8 @@ pub struct Connection<C = Pin<Box<dyn AsyncStream + Send + Sync>>> {
     // exit the pubsub state before executing the new request.
     pubsub: bool,
 
-    // Flag indicating whether resp3 mode is enabled.
-    resp3: bool,
+    // Field indicating which protocol to use for server communications.
+    protocol: ProtocolVersion,
 }
 
 fn assert_sync<T: Sync>() {}
@@ -59,7 +59,7 @@ impl<C> Connection<C> {
             decoder,
             db,
             pubsub,
-            resp3,
+            protocol,
         } = self;
         Connection {
             con: f(con),
@@ -67,7 +67,7 @@ impl<C> Connection<C> {
             decoder,
             db,
             pubsub,
-            resp3,
+            protocol,
         }
     }
 }
@@ -85,7 +85,7 @@ where
             decoder: combine::stream::Decoder::new(),
             db: connection_info.db,
             pubsub: false,
-            resp3: connection_info.use_resp3,
+            protocol: connection_info.protocol,
         };
         setup_connection(connection_info, &mut rv).await?;
         Ok(rv)
@@ -152,7 +152,7 @@ where
         // messages are received until the _subscription count_ in the responses reach zero.
         let mut received_unsub = false;
         let mut received_punsub = false;
-        if self.resp3 {
+        if self.protocol == ProtocolVersion::RESP3 {
             while let Value::Push { kind, data } = from_redis_value(&self.read_response().await?)? {
                 if data.len() >= 2 {
                     if let Value::Int(num) = data[1] {
@@ -321,7 +321,7 @@ where
     pub async fn subscribe<T: ToRedisArgs>(&mut self, channel: T) -> RedisResult<()> {
         let mut cmd = cmd("SUBSCRIBE");
         cmd.arg(channel);
-        if self.0.resp3 {
+        if self.0.protocol == ProtocolVersion::RESP3 {
             cmd.set_no_response(true);
         }
         cmd.query_async(&mut self.0).await
@@ -331,7 +331,7 @@ where
     pub async fn psubscribe<T: ToRedisArgs>(&mut self, pchannel: T) -> RedisResult<()> {
         let mut cmd = cmd("PSUBSCRIBE");
         cmd.arg(pchannel);
-        if self.0.resp3 {
+        if self.0.protocol == ProtocolVersion::RESP3 {
             cmd.set_no_response(true);
         }
         cmd.query_async(&mut self.0).await
@@ -341,7 +341,7 @@ where
     pub async fn unsubscribe<T: ToRedisArgs>(&mut self, channel: T) -> RedisResult<()> {
         let mut cmd = cmd("UNSUBSCRIBE");
         cmd.arg(channel);
-        if self.0.resp3 {
+        if self.0.protocol == ProtocolVersion::RESP3 {
             cmd.set_no_response(true);
         }
         cmd.query_async(&mut self.0).await
@@ -351,7 +351,7 @@ where
     pub async fn punsubscribe<T: ToRedisArgs>(&mut self, pchannel: T) -> RedisResult<()> {
         let mut cmd = cmd("PUNSUBSCRIBE");
         cmd.arg(pchannel);
-        if self.0.resp3 {
+        if self.0.protocol == ProtocolVersion::RESP3 {
             cmd.set_no_response(true);
         }
         cmd.query_async(&mut self.0).await

--- a/redis/src/aio/mod.rs
+++ b/redis/src/aio/mod.rs
@@ -2,6 +2,7 @@
 use crate::cmd::{cmd, Cmd};
 use crate::connection::{get_resp3_hello_command_error, RedisConnectionInfo};
 use crate::types::{ErrorKind, RedisFuture, RedisResult, Value};
+use crate::ProtocolVersion;
 use ::tokio::io::{AsyncRead, AsyncWrite};
 use async_trait::async_trait;
 use futures_util::Future;
@@ -84,7 +85,7 @@ async fn setup_connection<C>(connection_info: &RedisConnectionInfo, con: &mut C)
 where
     C: ConnectionLike,
 {
-    if connection_info.use_resp3 {
+    if connection_info.protocol == ProtocolVersion::RESP3 {
         let hello_cmd = resp3_hello(connection_info);
         let val: RedisResult<Value> = hello_cmd.query_async(con).await;
         if let Err(err) = val {

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -970,8 +970,8 @@ pub(crate) fn get_connection_info(
             password: cluster_params.password,
             username: cluster_params.username,
             client_name: cluster_params.client_name,
-            use_resp3: cluster_params.use_resp3,
-            ..Default::default()
+            protocol: cluster_params.protocol,
+            db: 0,
         },
     })
 }

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -5,7 +5,7 @@ use rand::Rng;
 use crate::cluster_topology::ReadFromReplicaStrategy;
 use crate::connection::{ConnectionAddr, ConnectionInfo, IntoConnectionInfo};
 use crate::types::{ErrorKind, RedisError, RedisResult};
-use crate::{cluster, TlsMode};
+use crate::{cluster, ProtocolVersion, TlsMode};
 
 #[cfg(feature = "tls-rustls")]
 use crate::tls::TlsConnParams;
@@ -34,7 +34,7 @@ struct BuilderParams {
     connection_timeout: Option<Duration>,
     topology_checks_interval: Option<Duration>,
     client_name: Option<String>,
-    use_resp3: bool,
+    protocol: ProtocolVersion,
 }
 
 #[derive(Clone)]
@@ -89,7 +89,7 @@ pub(crate) struct ClusterParams {
     pub(crate) topology_checks_interval: Option<Duration>,
     pub(crate) tls_params: Option<TlsConnParams>,
     pub(crate) client_name: Option<String>,
-    pub(crate) use_resp3: bool,
+    pub(crate) protocol: ProtocolVersion,
 }
 
 impl ClusterParams {
@@ -114,7 +114,7 @@ impl ClusterParams {
             topology_checks_interval: value.topology_checks_interval,
             tls_params,
             client_name: value.client_name,
-            use_resp3: value.use_resp3,
+            protocol: value.protocol,
         })
     }
 }
@@ -336,11 +336,9 @@ impl ClusterClientBuilder {
         self
     }
 
-    /// Sets whether the new ClusterClient should connect to the servers using RESP3.
-    ///
-    /// If not set, the default is to use RESP3.
-    pub fn use_resp3(mut self, use_resp3: bool) -> ClusterClientBuilder {
-        self.builder_params.use_resp3 = use_resp3;
+    /// Sets the protocol with which the client should communicate with the server.
+    pub fn use_protocol(mut self, protocol: ProtocolVersion) -> ClusterClientBuilder {
+        self.builder_params.protocol = protocol;
         self
     }
 

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -406,7 +406,8 @@ pub use crate::types::{
     // low level values
     Value,
     PushKind,
-    VerbatimFormat
+    VerbatimFormat,
+    ProtocolVersion
 };
 
 #[cfg(feature = "aio")]

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -58,8 +58,7 @@
 //!                 db: 1,
 //!                 username: Some(String::from("foo")),
 //!                 password: Some(String::from("bar")),
-//!                 use_resp3: false,
-//!                 client_name: None
+//!                 ..Default::default()
 //!             }),
 //!         }),
 //!     )
@@ -92,11 +91,9 @@
 //!     Some(SentinelNodeConnectionInfo {
 //!         tls_mode: Some(redis::TlsMode::Insecure),
 //!         redis_connection_info: Some(RedisConnectionInfo {
-//!             db: 0,
 //!             username: Some(String::from("user")),
 //!             password: Some(String::from("pass")),
-//!             use_resp3: false,
-//!             client_name: None
+//!             ..Default::default()
 //!         }),
 //!     }),
 //!     redis::sentinel::SentinelServerType::Master,

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -1766,3 +1766,14 @@ impl FromRedisValue for bytes::Bytes {
 pub fn from_redis_value<T: FromRedisValue>(v: &Value) -> RedisResult<T> {
     FromRedisValue::from_redis_value(v)
 }
+
+/// Enum representing the communication protocol with the server. This enum represents the types
+/// of data that the server can send to the client, and the capabilities that the client can use.
+#[derive(Clone, Eq, PartialEq, Default, Debug, Copy)]
+pub enum ProtocolVersion {
+    /// <https://github.com/redis/redis-specifications/blob/master/protocol/RESP2.md>
+    #[default]
+    RESP2,
+    /// <https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md>
+    RESP3,
+}

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -16,7 +16,7 @@ use tempfile::TempDir;
 
 use crate::support::{build_keys_and_certs_for_tls, Module};
 
-use super::use_resp3;
+use super::use_protocol;
 #[cfg(feature = "tls-rustls")]
 use super::{build_single_client, load_certs_from_file};
 
@@ -348,7 +348,7 @@ impl TestClusterContext {
             .map(RedisServer::connection_info)
             .collect();
         let mut builder = redis::cluster::ClusterClientBuilder::new(initial_nodes.clone());
-        builder = builder.use_resp3(use_resp3());
+        builder = builder.use_protocol(use_protocol());
 
         #[cfg(feature = "tls-rustls")]
         if mtls_enabled {

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -468,11 +468,8 @@ async fn invalid_password_issue_343() {
     let coninfo = redis::ConnectionInfo {
         addr: ctx.server.client_addr().clone(),
         redis: redis::RedisConnectionInfo {
-            db: 0,
-            username: None,
             password: Some("asdcasc".to_string()),
-            use_resp3: false,
-            client_name: None,
+            ..Default::default()
         },
     };
     let client = redis::Client::open(coninfo).unwrap();

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -1219,6 +1219,8 @@ fn test_zrembylex() {
 #[cfg(not(target_os = "windows"))]
 #[test]
 fn test_zrandmember() {
+    use redis::ProtocolVersion;
+
     let ctx = TestContext::new();
     let mut con = ctx.connection();
 
@@ -1250,7 +1252,7 @@ fn test_zrandmember() {
     let results: Vec<String> = con.zrandmember(setname, Some(-5)).unwrap();
     assert_eq!(results.len(), 5);
 
-    if !ctx.use_resp3 {
+    if ctx.protocol == ProtocolVersion::RESP2 {
         let results: Vec<String> = con.zrandmember_withscores(setname, 5).unwrap();
         assert_eq!(results.len(), 10);
 

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -8,7 +8,8 @@ use std::sync::{
 use crate::support::*;
 use redis::{
     cluster::{cluster_pipe, ClusterClient},
-    cmd, parse_redis_value, Commands, ConnectionLike, ErrorKind, RedisError, Value,
+    cmd, parse_redis_value, Commands, ConnectionLike, ErrorKind, ProtocolVersion, RedisError,
+    Value,
 };
 
 #[test]
@@ -138,7 +139,7 @@ fn test_cluster_multi_shard_commands() {
 
 #[test]
 fn test_cluster_resp3() {
-    if !use_resp3() {
+    if use_protocol() == ProtocolVersion::RESP2 {
         return;
     }
     let cluster = TestClusterContext::new(3, 0);

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -16,6 +16,7 @@ use once_cell::sync::Lazy;
 use redis::cluster_routing::Route;
 use redis::cluster_routing::SingleNodeRoutingInfo;
 use redis::cluster_routing::SlotAddr;
+use redis::ProtocolVersion;
 
 use redis::{
     aio::{ConnectionLike, MultiplexedConnection},
@@ -205,7 +206,7 @@ fn test_async_cluster_route_info_to_nodes() {
 
 #[test]
 fn test_cluster_resp3() {
-    if !use_resp3() {
+    if use_protocol() == ProtocolVersion::RESP2 {
         return;
     }
     block_on_all(async move {


### PR DESCRIPTION
Since there's a discussion starting about what might become RESP4, this PR will make it easier to add more RESP versions in the future.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
