### PR TITLE
Catch panics from task::spawn in tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test:
 	@echo "===================================================================="
 	@echo "Testing Connection Type UNIX SOCKETS"
 	@echo "===================================================================="
-	@REDISRS_SERVER_TYPE=unix RUST_BACKTRACE=1 cargo test -p redis --all-features -- --skip test_cluster --skip test_async_cluster --skip test_module
+	@REDISRS_SERVER_TYPE=unix RUST_BACKTRACE=1 cargo test -p redis --all-features -- --test-threads=1 --skip test_cluster --skip test_async_cluster --skip test_module 
 
 	@echo "===================================================================="
 	@echo "Testing async-std with Rustls"

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -39,12 +39,64 @@ pub fn current_thread_runtime() -> tokio::runtime::Runtime {
     builder.build().unwrap()
 }
 
-pub fn block_on_all<F>(f: F) -> F::Output
+#[cfg(feature = "aio")]
+pub fn block_on_all<F, V>(f: F) -> F::Output
 where
-    F: Future,
+    F: Future<Output = redis::RedisResult<V>>,
 {
-    current_thread_runtime().block_on(f)
+    use std::panic;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    static CHECK: AtomicBool = AtomicBool::new(false);
+
+    // TODO - this solution is purely single threaded, and won't work on multiple threads at the same time.
+    // This is needed because Tokio's Runtime silently ignores panics - https://users.rust-lang.org/t/tokio-runtime-what-happens-when-a-thread-panics/95819
+    // Once Tokio stabilizes the `unhandled_panic` field on the runtime builder, it should be used instead.
+    panic::set_hook(Box::new(|panic| {
+        println!("Panic: {panic}");
+        CHECK.store(true, Ordering::Relaxed);
+    }));
+
+    // This continuously query the flag, in order to abort ASAP after a panic.
+    let check_future = futures_util::FutureExt::fuse(async {
+        loop {
+            if CHECK.load(Ordering::Relaxed) {
+                return Err((redis::ErrorKind::IoError, "panic was caught").into());
+            }
+            futures_time::task::sleep(futures_time::time::Duration::from_millis(1)).await;
+        }
+    });
+    let f = futures_util::FutureExt::fuse(f);
+    futures::pin_mut!(f, check_future);
+
+    let res = current_thread_runtime().block_on(async {
+        futures::select! {res = f => res, err = check_future => err}
+    });
+
+    let _ = panic::take_hook();
+    if CHECK.swap(false, Ordering::Relaxed) {
+        panic!("Internal thread panicked");
+    }
+
+    res
 }
+
+#[cfg(feature = "aio")]
+#[test]
+fn test_block_on_all_panics_from_spawns() {
+    let result = std::panic::catch_unwind(|| {
+        block_on_all(async {
+            tokio::task::spawn(async {
+                futures_time::task::sleep(futures_time::time::Duration::from_millis(1)).await;
+                panic!("As it should");
+            });
+            futures_time::task::sleep(futures_time::time::Duration::from_millis(10)).await;
+            Ok(())
+        })
+    });
+    assert!(result.is_err());
+}
+
 #[cfg(feature = "async-std-comp")]
 pub fn block_on_all_using_async_std<F>(f: F) -> F::Output
 where

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -66,8 +66,10 @@ fn dont_panic_on_closed_multiplexed_connection() {
                     result.as_ref().unwrap_err()
                 );
             })
-            .await
-    });
+            .await;
+        Ok(())
+    })
+    .unwrap();
 }
 
 #[test]
@@ -118,7 +120,9 @@ fn test_client_tracking_doesnt_block_execution() {
         let _: RedisResult<()> = pipe.query_async(&mut con).await;
         let num: i32 = con.get("key_1").await.unwrap();
         assert_eq!(num, 42);
-    });
+        Ok(())
+    })
+    .unwrap();
 }
 
 #[test]
@@ -387,7 +391,9 @@ fn test_script_load() {
 
         let hash = script.prepare_invoke().load_async(&mut con).await.unwrap();
         assert_eq!(hash, script.get_hash().to_string());
-    });
+        Ok(())
+    })
+    .unwrap();
 }
 
 #[test]
@@ -715,7 +721,9 @@ fn test_connection_manager_reconnect_after_delay() {
 
         let result: redis::Value = manager.set("foo", "bar").await.unwrap();
         assert_eq!(result, redis::Value::Okay);
-    });
+        Ok(())
+    })
+    .unwrap();
 }
 
 #[cfg(feature = "tls-rustls")]

--- a/redis/tests/test_async_async_std.rs
+++ b/redis/tests/test_async_async_std.rs
@@ -301,7 +301,9 @@ fn test_script_load() {
 
         let hash = script.prepare_invoke().load_async(&mut con).await.unwrap();
         assert_eq!(hash, script.get_hash().to_string());
-    });
+        Ok(())
+    })
+    .unwrap();
 }
 
 #[test]

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -237,7 +237,9 @@ fn test_cluster_resp3() {
                 )
             ])
         );
-    });
+        Ok(())
+    })
+    .unwrap();
 }
 
 #[ignore] // TODO Handle pipe where the keys do not all go to the same node


### PR DESCRIPTION
ATM Tokio's runtimes hide panics from spawned tasks, and continue running. This PR ensures that we'll be catch panics even if they're thrown in spawned tasks.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
