### PR TITLE
Remove unnecessary todos.

### DIFF
--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -136,7 +136,7 @@ where
         self.0
             .send(Message {
                 cmd: CmdArg::Cmd {
-                    cmd: Arc::new(cmd.clone()), // TODO Remove this clone?
+                    cmd: Arc::new(cmd.clone()),
                     routing: routing.into(),
                 },
                 sender,
@@ -174,7 +174,7 @@ where
         self.0
             .send(Message {
                 cmd: CmdArg::Pipeline {
-                    pipeline: Arc::new(pipeline.clone()), // TODO Remove this clone?
+                    pipeline: Arc::new(pipeline.clone()),
                     offset,
                     count,
                     route: route.into(),


### PR DESCRIPTION
These TODOs can't be solved without a significant refactor, since the reference can't be saved for async operations without owning the value. If there will be such a refactor, it won't be because of these comments.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
