### PR TITLE
Fix issues with slot parsing in cluster connections.

### DIFF
--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -49,7 +49,7 @@ use crate::cluster_routing::{
     MultipleNodeRoutingInfo, ResponsePolicy, Routable, SingleNodeRoutingInfo, SlotAddr,
 };
 use crate::cluster_slotmap::SlotMap;
-use crate::cluster_topology::{parse_slots, SLOT_SIZE};
+use crate::cluster_topology::{parse_and_count_slots, SLOT_SIZE};
 use crate::cmd::{cmd, Cmd};
 use crate::connection::{
     connect, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike, RedisConnectionInfo,
@@ -381,9 +381,9 @@ where
         )));
         for conn in samples.iter_mut() {
             let value = conn.req_command(&slot_cmd())?;
-            match parse_slots(&value, self.cluster_params.tls)
-                .map(|slots_data| SlotMap::new(slots_data, self.cluster_params.read_from_replicas))
-            {
+            match parse_and_count_slots(&value, self.cluster_params.tls).map(|slots_data| {
+                SlotMap::new(slots_data.1, self.cluster_params.read_from_replicas)
+            }) {
                 Ok(new_slots) => {
                     result = Ok(new_slots);
                     break;

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -637,6 +637,11 @@ impl Slot {
     pub fn end(&self) -> u16 {
         self.end
     }
+
+    #[allow(dead_code)] // used in tests
+    pub(crate) fn master(&self) -> &str {
+        self.master.as_str()
+    }
 }
 
 /// What type of node should a request be routed to, assuming read from replica is enabled.

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -612,7 +612,7 @@ impl Routable for Value {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Hash)]
 pub(crate) struct Slot {
     start: u16,
     end: u16,

--- a/redis/src/cluster_topology.rs
+++ b/redis/src/cluster_topology.rs
@@ -330,57 +330,19 @@ mod tests {
     }
     fn get_view(view_type: &ViewType) -> Value {
         match view_type {
-            ViewType::SingleNodeViewFullCoverage => Value::Array(vec![Value::Array(vec![
-                Value::Int(0_i64),
-                Value::Int(16383_i64),
-                Value::Array(vec![
-                    Value::BulkString("node1".as_bytes().to_vec()),
-                    Value::Int(6379_i64),
-                ]),
-            ])]),
-            ViewType::SingleNodeViewMissingSlots => Value::Array(vec![Value::Array(vec![
-                Value::Int(0_i64),
-                Value::Int(4000_i64),
-                Value::Array(vec![
-                    Value::BulkString("node1".as_bytes().to_vec()),
-                    Value::Int(6379_i64),
-                ]),
-            ])]),
+            ViewType::SingleNodeViewFullCoverage => {
+                Value::Array(vec![slot_value(0, 16383, "node1", 6379)])
+            }
+            ViewType::SingleNodeViewMissingSlots => {
+                Value::Array(vec![slot_value(0, 4000, "node1", 6379)])
+            }
             ViewType::TwoNodesViewFullCoverage => Value::Array(vec![
-                Value::Array(vec![
-                    Value::Int(0_i64),
-                    Value::Int(4000_i64),
-                    Value::Array(vec![
-                        Value::BulkString("node1".as_bytes().to_vec()),
-                        Value::Int(6379_i64),
-                    ]),
-                ]),
-                Value::Array(vec![
-                    Value::Int(4001_i64),
-                    Value::Int(16383_i64),
-                    Value::Array(vec![
-                        Value::BulkString("node2".as_bytes().to_vec()),
-                        Value::Int(6380_i64),
-                    ]),
-                ]),
+                slot_value(0, 4000, "node1", 6379),
+                slot_value(4001, 16383, "node2", 6380),
             ]),
             ViewType::TwoNodesViewMissingSlots => Value::Array(vec![
-                Value::Array(vec![
-                    Value::Int(0_i64),
-                    Value::Int(3000_i64),
-                    Value::Array(vec![
-                        Value::BulkString("node3".as_bytes().to_vec()),
-                        Value::Int(6381_i64),
-                    ]),
-                ]),
-                Value::Array(vec![
-                    Value::Int(4001_i64),
-                    Value::Int(16383_i64),
-                    Value::Array(vec![
-                        Value::BulkString("node4".as_bytes().to_vec()),
-                        Value::Int(6382_i64),
-                    ]),
-                ]),
+                slot_value(0, 3000, "node3", 6381),
+                slot_value(4001, 16383, "node4", 6382),
             ]),
         }
     }

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -144,7 +144,7 @@ pub enum ErrorKind {
 }
 
 /// Internal low-level redis value enum.
-#[derive(PartialEq, Eq, Clone, Hash)]
+#[derive(PartialEq, Eq, Clone)]
 pub enum Value {
     /// A nil response from the server.
     Nil,

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -269,6 +269,32 @@ fn test_cluster_pipeline_invalid_command() {
 }
 
 #[test]
+fn test_cluster_can_connect_to_server_that_sends_cluster_slots_without_host_name() {
+    let name = "test_cluster_can_connect_to_server_that_sends_cluster_slots_without_host_name";
+
+    let MockEnv { mut connection, .. } = MockEnv::new(name, move |cmd: &[u8], _| {
+        if contains_slice(cmd, b"PING") {
+            Err(Ok(Value::SimpleString("OK".into())))
+        } else if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
+            Err(Ok(Value::Array(vec![Value::Array(vec![
+                Value::Int(0),
+                Value::Int(16383),
+                Value::Array(vec![
+                    Value::BulkString("".as_bytes().to_vec()),
+                    Value::Int(6379),
+                ]),
+            ])])))
+        } else {
+            Err(Ok(Value::Nil))
+        }
+    });
+
+    let value = cmd("GET").arg("test").query::<Value>(&mut connection);
+
+    assert_eq!(value, Ok(Value::Nil));
+}
+
+#[test]
 fn test_cluster_pipeline_command_ordering() {
     let cluster = TestClusterContext::new(3, 0);
     cluster.wait_for_cluster_up();

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -506,6 +506,41 @@ fn test_async_cluster_async_std_basic_cmd() {
 }
 
 #[test]
+fn test_cluster_async_can_connect_to_server_that_sends_cluster_slots_without_host_name() {
+    let name =
+        "test_cluster_async_can_connect_to_server_that_sends_cluster_slots_without_host_name";
+
+    let MockEnv {
+        runtime,
+        async_connection: mut connection,
+        ..
+    } = MockEnv::new(name, move |cmd: &[u8], _| {
+        if contains_slice(cmd, b"PING") {
+            Err(Ok(Value::SimpleString("OK".into())))
+        } else if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
+            Err(Ok(Value::Array(vec![Value::Array(vec![
+                Value::Int(0),
+                Value::Int(16383),
+                Value::Array(vec![
+                    Value::BulkString("".as_bytes().to_vec()),
+                    Value::Int(6379),
+                ]),
+            ])])))
+        } else {
+            Err(Ok(Value::Nil))
+        }
+    });
+
+    let value = runtime.block_on(
+        cmd("GET")
+            .arg("test")
+            .query_async::<_, Value>(&mut connection),
+    );
+
+    assert_eq!(value, Ok(Value::Nil));
+}
+
+#[test]
 fn test_async_cluster_retries() {
     let name = "tryagain";
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/babushka/issues/659
https://github.com/aws/babushka/issues/532
https://github.com/aws/babushka/issues/430

*Description of changes:*
based over https://github.com/amazon-contributing/redis-rs/pull/95

1. When parsing slots, now the slots will be sorted, to ensure that they're ordered the same way regardless of the order returned from the server.
2. When parsing slots, if hostname is missing, fill it in with the queried node's hostname.
3. Hash the topology view according to the parsed slots instead of the returned values, in order to account for the 2 fixes in the hash.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
