### PR TITLE
Handle loading errors.

### DIFF
--- a/redis/src/cluster_async/connections_container.rs
+++ b/redis/src/cluster_async/connections_container.rs
@@ -113,7 +113,6 @@ where
     }
 
     /// Returns true if the identifier represents a known primary node.
-    #[allow(dead_code)]
     pub(crate) fn is_primary(&self, identifier: &Identifier) -> bool {
         self.connection_for_identifier(identifier).is_some()
             && self

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -425,6 +425,10 @@ enum Next<C> {
     Retry {
         request: PendingRequest<C>,
     },
+    RetryBusyLoadingError {
+        request: PendingRequest<C>,
+        identifier: ConnectionIdentifier,
+    },
     Reconnect {
         request: PendingRequest<C>,
         target: ConnectionIdentifier,
@@ -534,6 +538,11 @@ impl<C> Future for Request<C> {
                         }
                         .into()
                     }
+                    ErrorKind::BusyLoadingError => Next::RetryBusyLoadingError {
+                        request: this.request.take().unwrap(),
+                        identifier,
+                    }
+                    .into(),
                     _ => {
                         if err.is_retryable() {
                             Next::Retry {
@@ -1324,6 +1333,22 @@ where
         }
     }
 
+    async fn handle_loading_error(
+        core: Core<C>,
+        info: RequestInfo<C>,
+        identifier: ConnectionIdentifier,
+    ) -> OperationResult {
+        let is_primary = core.conn_lock.read().await.is_primary(&identifier);
+
+        if !is_primary {
+            // If the connection is a replica, remove the connection and retry.
+            // The connection will be established again on the next call to refresh slots once the replica is no longer in loading state.
+            core.conn_lock.write().await.remove_node(&identifier);
+        }
+
+        Self::try_request(info, core).await
+    }
+
     fn poll_complete(&mut self, cx: &mut task::Context<'_>) -> Poll<PollFlushAction> {
         let mut poll_flush_action = PollFlushAction::None;
 
@@ -1358,6 +1383,24 @@ where
                 Next::Done => {}
                 Next::Retry { request } => {
                     let future = Self::try_request(request.info.clone(), self.inner.clone());
+                    self.in_flight_requests.push(Box::pin(Request {
+                        retry_params: self.inner.cluster_params.retry_params.clone(),
+                        request: Some(request),
+                        future: RequestState::Future {
+                            future: Box::pin(future),
+                        },
+                    }));
+                }
+                Next::RetryBusyLoadingError {
+                    request,
+                    identifier,
+                } => {
+                    // TODO - do we also want to try and reconnect to replica if it is loading?
+                    let future = Self::handle_loading_error(
+                        self.inner.clone(),
+                        request.info.clone(),
+                        identifier,
+                    );
                     self.in_flight_requests.push(Box::pin(Request {
                         retry_params: self.inner.cluster_params.retry_params.clone(),
                         request: Some(request),

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -2234,9 +2234,9 @@ fn test_async_cluster_reroute_from_replica_if_in_loading_state() {
 }
 
 #[test]
-fn test_async_cluster_replica_read_primary_loading() {
-    // Test primary in loading state. The expected behaviour is that the request will be retried until the primary is no loner in loading state.
-    let name = "test_async_cluster_replica_read_primary_loading";
+fn test_async_cluster_read_from_primary_when_primary_loading() {
+    // Test primary in loading state. The expected behaviour is that the request will be retried until the primary is no longer in loading state.
+    let name = "test_async_cluster_read_from_primary_when_primary_loading";
 
     const RETRIES: u32 = 3;
     const ITERATIONS: u32 = 2;


### PR DESCRIPTION
Loading errors on primary should retry, and on replica should remove the replica & retry.

*Issue #, if available:*
https://github.com/aws/glide-for-redis/issues/324

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
