### PR TITLE
Added handling to "?" and NULL hostnames in CLUSTER SLOTS

### DIFF
--- a/redis/tests/support/mock_cluster.rs
+++ b/redis/tests/support/mock_cluster.rs
@@ -54,6 +54,13 @@ impl MockConnectionBehavior {
     }
 }
 
+pub fn add_new_mock_connection_behavior(name: &str, handler: Handler) {
+    MOCK_CONN_BEHAVIORS
+        .write()
+        .unwrap()
+        .insert(name.to_string(), MockConnectionBehavior::new(name, handler));
+}
+
 pub fn modify_mock_connection_behavior(name: &str, func: impl FnOnce(&mut MockConnectionBehavior)) {
     func(
         MOCK_CONN_BEHAVIORS
@@ -433,10 +440,7 @@ impl MockEnv {
             .unwrap();
 
         let id = id.to_string();
-        MOCK_CONN_BEHAVIORS.write().unwrap().insert(
-            id.clone(),
-            MockConnectionBehavior::new(&id, Arc::new(move |cmd, port| handler(cmd, port))),
-        );
+        add_new_mock_connection_behavior(&id, Arc::new(move |cmd, port| handler(cmd, port)));
         let client = client_builder.build().unwrap();
         let connection = client.get_generic_connection().unwrap();
         #[cfg(feature = "cluster-async")]

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -541,6 +541,119 @@ fn test_cluster_async_can_connect_to_server_that_sends_cluster_slots_without_hos
 }
 
 #[test]
+fn test_cluster_async_can_connect_to_server_that_sends_cluster_slots_with_null_host_name() {
+    let name =
+        "test_cluster_async_can_connect_to_server_that_sends_cluster_slots_with_null_host_name";
+
+    let MockEnv {
+        runtime,
+        async_connection: mut connection,
+        ..
+    } = MockEnv::new(name, move |cmd: &[u8], _| {
+        if contains_slice(cmd, b"PING") {
+            Err(Ok(Value::SimpleString("OK".into())))
+        } else if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
+            Err(Ok(Value::Array(vec![Value::Array(vec![
+                Value::Int(0),
+                Value::Int(16383),
+                Value::Array(vec![Value::Nil, Value::Int(6379)]),
+            ])])))
+        } else {
+            Err(Ok(Value::Nil))
+        }
+    });
+
+    let value = runtime.block_on(
+        cmd("GET")
+            .arg("test")
+            .query_async::<_, Value>(&mut connection),
+    );
+
+    assert_eq!(value, Ok(Value::Nil));
+}
+
+#[test]
+fn test_cluster_async_cannot_connect_to_server_with_unknown_host_name() {
+    let name = "test_cluster_async_cannot_connect_to_server_with_unknown_host_name";
+    let handler = move |cmd: &[u8], _| {
+        if contains_slice(cmd, b"PING") {
+            Err(Ok(Value::SimpleString("OK".into())))
+        } else if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
+            Err(Ok(Value::Array(vec![Value::Array(vec![
+                Value::Int(0),
+                Value::Int(16383),
+                Value::Array(vec![
+                    Value::BulkString("?".as_bytes().to_vec()),
+                    Value::Int(6379),
+                ]),
+            ])])))
+        } else {
+            Err(Ok(Value::Nil))
+        }
+    };
+    let client_builder = ClusterClient::builder(vec![&*format!("redis://{name}")]);
+    let client = client_builder.build().unwrap();
+    MOCK_CONN_UTILS.write().unwrap().insert(
+        name.to_string(),
+        MockConnectionUtils {
+            handler: Some(Arc::new(handler)),
+            ..Default::default()
+        },
+    );
+    let connection = client.get_generic_connection::<MockConnection>();
+    assert!(connection.is_err());
+    let err = connection.err().unwrap();
+    assert!(err
+        .to_string()
+        .contains("Error parsing slots: No healthy node found"))
+}
+
+#[test]
+fn test_cluster_async_can_connect_to_server_that_sends_cluster_slots_with_partial_nodes_with_unknown_host_name(
+) {
+    let name = "test_cluster_async_can_connect_to_server_that_sends_cluster_slots_with_partial_nodes_with_unknown_host_name";
+
+    let MockEnv {
+        runtime,
+        async_connection: mut connection,
+        ..
+    } = MockEnv::new(name, move |cmd: &[u8], _| {
+        if contains_slice(cmd, b"PING") {
+            Err(Ok(Value::SimpleString("OK".into())))
+        } else if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
+            Err(Ok(Value::Array(vec![
+                Value::Array(vec![
+                    Value::Int(0),
+                    Value::Int(7000),
+                    Value::Array(vec![
+                        Value::BulkString(name.as_bytes().to_vec()),
+                        Value::Int(6379),
+                    ]),
+                ]),
+                Value::Array(vec![
+                    Value::Int(7001),
+                    Value::Int(16383),
+                    Value::Array(vec![
+                        Value::BulkString("?".as_bytes().to_vec()),
+                        Value::Int(6380),
+                    ]),
+                ]),
+            ])))
+        } else {
+            Err(Ok(Value::Nil))
+        }
+    });
+
+    let value = runtime.block_on(
+        cmd("GET")
+            .arg("test")
+            .query_async::<_, Value>(&mut connection),
+    );
+
+    assert_eq!(value, Ok(Value::Nil));
+}
+
+#[test]
 fn test_async_cluster_retries() {
     let name = "tryagain";
 

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -593,13 +593,7 @@ fn test_cluster_async_cannot_connect_to_server_with_unknown_host_name() {
     };
     let client_builder = ClusterClient::builder(vec![&*format!("redis://{name}")]);
     let client = client_builder.build().unwrap();
-    MOCK_CONN_UTILS.write().unwrap().insert(
-        name.to_string(),
-        MockConnectionUtils {
-            handler: Some(Arc::new(handler)),
-            ..Default::default()
-        },
-    );
+    add_new_mock_connection_behavior(name, Arc::new(handler));
     let connection = client.get_generic_connection::<MockConnection>();
     assert!(connection.is_err());
     let err = connection.err().unwrap();


### PR DESCRIPTION
Based on the description of CLUSTER SLOTS (https://redis.io/commands/cluster-slots/):
> The preferred endpoint, along with the port, defines the location that clients should use to send requests for a given slot. A NULL value for the endpoint indicates the node has an unknown endpoint and the client should connect to the same endpoint it used to send the CLUSTER SLOTS command but with the port returned from the command. This unknown endpoint configuration is useful when the Redis nodes are behind a load balancer that Redis doesn't know the endpoint of. Which endpoint is set as preferred is determined by the cluster-preferred-endpoint-type config. An empty string "" is another abnormal value of the endpoint field, as well as for the ip field, which is returned if the node doesn't know its own IP address. This can happen in a cluster that consists of only one node or the node has not yet been joined with the rest of the cluster. The value ? is displayed if the node is incorrectly configured to use announced hostnames but no hostname is configured using cluster-announce-hostname. Clients may treat the empty string in the same way as NULL, that is the same endpoint it used to send the current command to, while "?" should be treated as an unknown node, not necessarily the same node as the one serving the current command.

