### PR TITLE
Create connections logic file.

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -162,6 +162,10 @@ required-features = ["json", "serde/derive"]
 name = "test_cluster_async"
 required-features = ["cluster-async"]
 
+[[test]]
+name = "test_async_cluster_connections_logic"
+required-features = ["cluster-async"]
+
 [[bench]]
 name = "bench_basic"
 harness = false

--- a/redis/src/cluster_async/connections_logic.rs
+++ b/redis/src/cluster_async/connections_logic.rs
@@ -1,0 +1,102 @@
+use super::{AsyncClusterNode, Connect};
+use crate::{
+    aio::{get_socket_addrs, ConnectionLike},
+    cluster::get_connection_info,
+    cluster_client::ClusterParams,
+    RedisResult,
+};
+use futures_time::future::FutureExt;
+use std::{
+    iter::Iterator,
+    net::{IpAddr, SocketAddr},
+};
+
+/// Return true if a DNS change is detected, otherwise return false.
+/// This function takes a node's address, examines if its host has encountered a DNS change, where the node's endpoint now leads to a different IP address.
+/// If no socket addresses are discovered for the node's host address, or if it's a non-DNS address, it returns false.
+/// In case the node's host address resolves to socket addresses and none of them match the current connection's IP,
+/// a DNS change is detected, so the current connection isn't valid anymore and a new connection should be made.
+async fn is_dns_changed(addr: &str, curr_ip: &IpAddr) -> bool {
+    let (host, port) = match get_host_and_port_from_addr(addr) {
+        Some((host, port)) => (host, port),
+        None => return false,
+    };
+    let mut updated_addresses = match get_socket_addrs(host, port).await {
+        Ok(socket_addrs) => socket_addrs,
+        Err(_) => return false,
+    };
+
+    !updated_addresses.any(|socket_addr| socket_addr.ip() == *curr_ip)
+}
+
+pub(crate) async fn get_or_create_conn<C>(
+    addr: &str,
+    node: Option<AsyncClusterNode<C>>,
+    params: &ClusterParams,
+) -> RedisResult<(C, Option<IpAddr>)>
+where
+    C: ConnectionLike + Connect + Send + Clone + 'static,
+{
+    if let Some(node) = node {
+        let mut conn = node.user_connection.await;
+        if let Some(ref ip) = node.ip {
+            if is_dns_changed(addr, ip).await {
+                return connect_and_check(addr, params.clone(), None).await;
+            }
+        };
+        match check_connection(&mut conn, params.connection_timeout.into()).await {
+            Ok(_) => Ok((conn, node.ip)),
+            Err(_) => connect_and_check(addr, params.clone(), None).await,
+        }
+    } else {
+        connect_and_check(addr, params.clone(), None).await
+    }
+}
+
+#[doc(hidden)]
+pub async fn connect_and_check<C>(
+    node: &str,
+    params: ClusterParams,
+    socket_addr: Option<SocketAddr>,
+) -> RedisResult<(C, Option<IpAddr>)>
+where
+    C: ConnectionLike + Connect + Send + 'static,
+{
+    let read_from_replicas = params.read_from_replicas
+        != crate::cluster_slotmap::ReadFromReplicaStrategy::AlwaysFromPrimary;
+    let connection_timeout = params.connection_timeout;
+    let response_timeout = params.response_timeout;
+    let info = get_connection_info(node, params)?;
+    let (mut conn, ip) =
+        C::connect(info, response_timeout, connection_timeout, socket_addr).await?;
+    check_connection(&mut conn, connection_timeout.into()).await?;
+    if read_from_replicas {
+        // If READONLY is sent to primary nodes, it will have no effect
+        crate::cmd("READONLY").query_async(&mut conn).await?;
+    }
+    Ok((conn, ip))
+}
+
+async fn check_connection<C>(conn: &mut C, timeout: futures_time::time::Duration) -> RedisResult<()>
+where
+    C: ConnectionLike + Send + 'static,
+{
+    // TODO: Add a check to re-resolve DNS addresses to verify we that we have a connection to the right node
+    crate::cmd("PING")
+        .query_async::<_, String>(conn)
+        .timeout(timeout)
+        .await??;
+    Ok(())
+}
+
+/// Splits a string address into host and port. If the passed address cannot be parsed, None is returned.
+/// [addr] should be in the following format: "<host>:<port>".
+pub(crate) fn get_host_and_port_from_addr(addr: &str) -> Option<(&str, u16)> {
+    let parts: Vec<&str> = addr.split(':').collect();
+    if parts.len() != 2 {
+        return None;
+    }
+    let host = parts.first().unwrap();
+    let port = parts.get(1).unwrap();
+    port.parse::<u16>().ok().map(|port| (*host, port))
+}

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -23,6 +23,8 @@
 //! ```
 
 mod connections_container;
+#[doc(hidden)]
+pub mod connections_logic;
 use std::{
     collections::HashMap,
     fmt, io,
@@ -40,8 +42,11 @@ use std::{
 
 use crate::{
     aio::{get_socket_addrs, ConnectionLike, MultiplexedConnection},
-    cluster::{get_connection_info, slot_cmd},
-    cluster_async::connections_container::ClusterNode,
+    cluster::slot_cmd,
+    cluster_async::{
+        connections_container::ClusterNode,
+        connections_logic::{get_host_and_port_from_addr, get_or_create_conn},
+    },
     cluster_client::{ClusterParams, RetryParams},
     cluster_routing::{
         self, MultipleNodeRoutingInfo, Redirect, ResponsePolicy, Route, SingleNodeRoutingInfo,
@@ -85,8 +90,11 @@ use tokio::sync::{
 };
 use tracing::{info, trace, warn};
 
-use self::connections_container::{
-    ConnectionAndIdentifier, ConnectionType, ConnectionsMap, Identifier as ConnectionIdentifier,
+use self::{
+    connections_container::{
+        ConnectionAndIdentifier, ConnectionType, ConnectionsMap, Identifier as ConnectionIdentifier,
+    },
+    connections_logic::connect_and_check,
 };
 
 /// This represents an async Redis Cluster connection. It stores the
@@ -744,8 +752,7 @@ where
                         let addr_option = connections_container.address_for_identifier(&identifier);
                         let node_option = connections_container.remove_node(&identifier);
                         if let Some(addr) = addr_option {
-                            let conn =
-                                Self::get_or_create_conn(&addr, node_option, cluster_params).await;
+                            let conn = get_or_create_conn(&addr, node_option, cluster_params).await;
                             if let Ok((conn, ip)) = conn {
                                 connections_container.replace_or_add_connection_for_address(
                                     addr,
@@ -987,8 +994,7 @@ where
             .fold(
                 ConnectionsMap(HashMap::with_capacity(nodes_len)),
                 |mut connections, (addr, connection)| async {
-                    let conn =
-                        Self::get_or_create_conn(addr, connection, &inner.cluster_params).await;
+                    let conn = get_or_create_conn(addr, connection, &inner.cluster_params).await;
                     if let Ok((conn, ip)) = conn {
                         connections.0.insert(
                             addr.into(),
@@ -1407,45 +1413,6 @@ where
             }
         }
     }
-
-    /// Return true if a DNS change is detected, otherwise return false.
-    /// This function takes a node's address, examines if its host has encountered a DNS change, where the node's endpoint now leads to a different IP address.
-    /// If no socket addresses are discovered for the node's host address, or if it's a non-DNS address, it returns false.
-    /// In case the node's host address resolves to socket addresses and none of them match the current connection's IP,
-    /// a DNS change is detected, so the current connection isn't valid anymore and a new connection should be made.
-    async fn is_dns_changed(addr: &str, curr_ip: &IpAddr) -> bool {
-        let (host, port) = match get_host_and_port_from_addr(addr) {
-            Some((host, port)) => (host, port),
-            None => return false,
-        };
-        let mut updated_addresses = match get_socket_addrs(host, port).await {
-            Ok(socket_addrs) => socket_addrs,
-            Err(_) => return false,
-        };
-
-        !updated_addresses.any(|socket_addr| socket_addr.ip() == *curr_ip)
-    }
-
-    async fn get_or_create_conn(
-        addr: &str,
-        node: Option<AsyncClusterNode<C>>,
-        params: &ClusterParams,
-    ) -> RedisResult<(C, Option<IpAddr>)> {
-        if let Some(node) = node {
-            let mut conn = node.user_connection.await;
-            if let Some(ref ip) = node.ip {
-                if Self::is_dns_changed(addr, ip).await {
-                    return connect_and_check(addr, params.clone(), None).await;
-                }
-            };
-            match check_connection(&mut conn, params.connection_timeout.into()).await {
-                Ok(_) => Ok((conn, node.ip)),
-                Err(_) => connect_and_check(addr, params.clone(), None).await,
-            }
-        } else {
-            connect_and_check(addr, params.clone(), None).await
-        }
-    }
 }
 
 enum PollFlushAction {
@@ -1720,53 +1687,6 @@ impl Connect for MultiplexedConnection {
         }
         .boxed()
     }
-}
-
-async fn connect_and_check<C>(
-    node: &str,
-    params: ClusterParams,
-    socket_addr: Option<SocketAddr>,
-) -> RedisResult<(C, Option<IpAddr>)>
-where
-    C: ConnectionLike + Connect + Send + 'static,
-{
-    let read_from_replicas = params.read_from_replicas
-        != crate::cluster_slotmap::ReadFromReplicaStrategy::AlwaysFromPrimary;
-    let connection_timeout = params.connection_timeout;
-    let response_timeout = params.response_timeout;
-    let info = get_connection_info(node, params)?;
-    let (mut conn, ip) =
-        C::connect(info, response_timeout, connection_timeout, socket_addr).await?;
-    check_connection(&mut conn, connection_timeout.into()).await?;
-    if read_from_replicas {
-        // If READONLY is sent to primary nodes, it will have no effect
-        crate::cmd("READONLY").query_async(&mut conn).await?;
-    }
-    Ok((conn, ip))
-}
-
-async fn check_connection<C>(conn: &mut C, timeout: futures_time::time::Duration) -> RedisResult<()>
-where
-    C: ConnectionLike + Send + 'static,
-{
-    // TODO: Add a check to re-resolve DNS addresses to verify we that we have a connection to the right node
-    crate::cmd("PING")
-        .query_async::<_, String>(conn)
-        .timeout(timeout)
-        .await??;
-    Ok(())
-}
-
-/// Splits a string address into host and port. If the passed address cannot be parsed, None is returned.
-/// [addr] should be in the following format: "<host>:<port>".
-fn get_host_and_port_from_addr(addr: &str) -> Option<(&str, u16)> {
-    let parts: Vec<&str> = addr.split(':').collect();
-    if parts.len() != 2 {
-        return None;
-    }
-    let host = parts.first().unwrap();
-    let port = parts.get(1).unwrap();
-    port.parse::<u16>().ok().map(|port| (*host, port))
 }
 
 #[cfg(test)]

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -77,7 +77,8 @@ impl RetryParams {
 
 /// Redis cluster specific parameters.
 #[derive(Default, Clone)]
-pub(crate) struct ClusterParams {
+#[doc(hidden)]
+pub struct ClusterParams {
     pub(crate) password: Option<String>,
     pub(crate) username: Option<String>,
     pub(crate) read_from_replicas: ReadFromReplicaStrategy,

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -448,6 +448,10 @@ mod cluster_slotmap;
 #[cfg(feature = "cluster")]
 mod cluster_client;
 
+// for testing purposes
+#[cfg(feature = "cluster")]
+pub use crate::cluster_client::ClusterParams;
+
 #[cfg(feature = "cluster")]
 mod cluster_pipeline;
 

--- a/redis/tests/test_async_cluster_connections_logic.rs
+++ b/redis/tests/test_async_cluster_connections_logic.rs
@@ -1,0 +1,39 @@
+#![cfg(feature = "cluster-async")]
+mod support;
+
+mod async_cluster_connection_logic {
+    use super::*;
+    use redis::{cluster_async::connections_logic::connect_and_check, ClusterParams};
+    use std::net::{IpAddr, Ipv4Addr};
+    use support::{respond_startup, ConnectionIPReturnType, MockEnv};
+
+    use crate::support::{modify_mock_connection_behavior, MockConnection};
+
+    #[test]
+    fn test_connect_and_check_connect_successfully() {
+        // Test that upon refreshing all connections, if both connections were successful,
+        // the returned node contains both user and management connection
+        let name = "test_connect_and_check_connect_successfully";
+
+        let mock_env = MockEnv::new(name, move |cmd, _| {
+            respond_startup(name, cmd)?;
+            Ok(())
+        });
+
+        let expected_ip = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+        modify_mock_connection_behavior(name, |behavior| {
+            behavior.returned_ip_type = ConnectionIPReturnType::Specified(expected_ip)
+        });
+
+        mock_env.runtime.block_on(async {
+            let (_conn, ip) = connect_and_check::<MockConnection>(
+                &format!("{name}:6379"),
+                ClusterParams::default(),
+                None,
+            )
+            .await
+            .unwrap();
+            assert_eq!(ip, Some(expected_ip));
+        })
+    }
+}


### PR DESCRIPTION
This moves the free connection functions from the async cluster to a separate file, and add tests to this file.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
