### PR TITLE
Reduce visibility of types that are used only for testing.

### DIFF
--- a/redis/src/cluster_async/connections_logic.rs
+++ b/redis/src/cluster_async/connections_logic.rs
@@ -3,7 +3,7 @@ use std::{
     net::{IpAddr, SocketAddr},
 };
 
-use super::{AsyncClusterNode, Connect};
+use super::{connections_container::ClusterNode, Connect};
 use crate::{
     aio::{get_socket_addrs, ConnectionLike},
     cluster::get_connection_info,
@@ -12,8 +12,13 @@ use crate::{
 };
 
 use futures_time::future::FutureExt;
-use futures_util::join;
+use futures_util::{future::BoxFuture, join};
 use tracing::warn;
+
+pub(crate) type ConnectionFuture<C> = futures::future::Shared<BoxFuture<'static, C>>;
+/// Cluster node for async connections
+#[doc(hidden)]
+pub type AsyncClusterNode<C> = ClusterNode<ConnectionFuture<C>>;
 
 #[doc(hidden)]
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -23,8 +23,11 @@
 //! ```
 
 mod connections_container;
-#[doc(hidden)]
-pub mod connections_logic;
+mod connections_logic;
+/// Exposed only for testing.
+pub mod testing {
+    pub use super::connections_logic::*;
+}
 use std::{
     collections::HashMap,
     fmt, io,
@@ -45,7 +48,7 @@ use crate::{
     cluster::slot_cmd,
     cluster_async::{
         connections_container::ClusterNode,
-        connections_logic::{get_host_and_port_from_addr, get_or_create_conn},
+        connections_logic::{get_host_and_port_from_addr, get_or_create_conn, ConnectionFuture},
     },
     cluster_client::{ClusterParams, RetryParams},
     cluster_routing::{
@@ -199,9 +202,6 @@ where
     }
 }
 
-type ConnectionFuture<C> = future::Shared<BoxFuture<'static, C>>;
-/// Cluster node for async connections
-pub type AsyncClusterNode<C> = ClusterNode<ConnectionFuture<C>>;
 type ConnectionMap<C> = connections_container::ConnectionsMap<ConnectionFuture<C>>;
 type ConnectionsContainer<C> =
     self::connections_container::ConnectionsContainer<ConnectionFuture<C>>;

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -449,9 +449,11 @@ mod cluster_slotmap;
 #[cfg(feature = "cluster")]
 mod cluster_client;
 
-// for testing purposes
-#[cfg(feature = "cluster")]
-pub use crate::cluster_client::ClusterParams;
+/// for testing purposes
+pub mod testing {
+    #[cfg(feature = "cluster")]
+    pub use crate::cluster_client::ClusterParams;
+}
 
 #[cfg(feature = "cluster")]
 mod cluster_pipeline;

--- a/redis/tests/test_async_cluster_connections_logic.rs
+++ b/redis/tests/test_async_cluster_connections_logic.rs
@@ -3,8 +3,9 @@ mod support;
 
 use futures_util::FutureExt;
 use redis::{
-    cluster_async::{connections_logic::RefreshConnectionType, AsyncClusterNode},
-    ClusterParams, ErrorKind,
+    cluster_async::testing::{AsyncClusterNode, RefreshConnectionType},
+    testing::ClusterParams,
+    ErrorKind,
 };
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
@@ -15,7 +16,7 @@ use support::{
 
 mod test_connect_and_check {
     use super::*;
-    use redis::cluster_async::connections_logic::connect_and_check;
+    use redis::cluster_async::testing::connect_and_check;
 
     #[tokio::test]
     async fn test_connect_and_check_connect_successfully() {
@@ -50,7 +51,7 @@ mod test_connect_and_check {
 mod test_check_node_connections {
 
     use super::*;
-    use redis::cluster_async::connections_logic::check_node_connections;
+    use redis::cluster_async::testing::check_node_connections;
 
     #[tokio::test]
     async fn test_check_node_connections_find_no_problem() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
These types will now be under a `testing` module, thus communicating that they shouldn't be used externally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
