### PR TITLE
Use management connections in topology refresh.

### DIFF
--- a/redis/src/cluster_async/connections_container.rs
+++ b/redis/src/cluster_async/connections_container.rs
@@ -36,7 +36,7 @@ where
     pub(crate) fn get_connection(&self, conn_type: &ConnectionType) -> Connection {
         match conn_type {
             ConnectionType::User => self.user_connection.clone(),
-            ConnectionType::_Management => self
+            ConnectionType::PreferManagement => self
                 .management_connection
                 .clone()
                 .unwrap_or_else(|| self.user_connection.clone()),
@@ -48,7 +48,7 @@ where
 
 pub(crate) enum ConnectionType {
     User,
-    _Management,
+    PreferManagement,
 }
 
 /// This opaque type allows us to change the way that the connections are organized
@@ -679,7 +679,7 @@ mod tests {
     fn get_random_management_connections() {
         let container = create_container_with_strategy(ReadFromReplicaStrategy::RoundRobin, true);
         let mut random_connections: Vec<_> = container
-            .random_connections(1000, ConnectionType::_Management)
+            .random_connections(1000, ConnectionType::PreferManagement)
             .map(|pair| pair.1)
             .collect();
         random_connections.sort();


### PR DESCRIPTION
Async cluster connection will now use additional, management connections in order to get topology refreshes.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
