### PR TITLE
Reconnect failing management connections.

### DIFF
--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -1743,12 +1743,9 @@ where
         .await;
     let failed_identifiers = topology_join_results
         .iter()
-        .filter_map(|(identifier, _, res)| {
-            if res.is_ok() {
-                None
-            } else {
-                Some(identifier.clone())
-            }
+        .filter_map(|(identifier, _, res)| match res {
+            Err(err) if err.is_unrecoverable_error() => Some(identifier.clone()),
+            _ => None,
         })
         .collect();
     let topology_values = topology_join_results.iter().filter_map(|(_, addr, res)| {

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -2260,21 +2260,21 @@ fn test_async_cluster_recover_disconnected_management_connections() {
         let max_requests = 5000;
 
         let connections = get_clients_names_to_ids(&mut connection, routing.clone().into()).await;
-        assert_eq!(connections.len(), 2);
+        assert!(connections.contains_key(MANAGEMENT_CONN_NAME));
         let management_conn_id = connections.get(MANAGEMENT_CONN_NAME).unwrap();
 
         // Get the connection ID of the management connection
         kill_connection(&mut connection, management_conn_id).await;
 
         let connections = get_clients_names_to_ids(&mut connection, routing.clone().into()).await;
-        assert_eq!(connections.len(), 1);
+        assert!(!connections.contains_key(MANAGEMENT_CONN_NAME));
 
         for _ in 0..max_requests {
             let _ = sleep(futures_time::time::Duration::from_millis(10)).await;
 
             let connections =
                 get_clients_names_to_ids(&mut connection, routing.clone().into()).await;
-            if connections.len() == 2 {
+            if connections.contains_key(MANAGEMENT_CONN_NAME) {
                 return Ok(());
             }
         }

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -2266,7 +2266,7 @@ fn test_async_cluster_recover_disconnected_management_connections() {
                     .unwrap(),
             )
             .unwrap();
-            string.split("\n").filter_map(|str|if str.is_empty() {None} else {Some(str.to_string())}).collect::<Vec<_>>()
+            string.split('\n').filter_map(|str|if str.is_empty() {None} else {Some(str.to_string())}).collect::<Vec<_>>()
         };
 
         let mut connection = cluster.async_connection().await;
@@ -2285,8 +2285,8 @@ fn test_async_cluster_recover_disconnected_management_connections() {
         let connections = get_connection_list(connection.clone(), routing.clone()).await;
         assert_eq!(connections.len(), 2);
 
-        for i in 0..connections.len() {
-            let id = parse_client_info(&connections[i])["id"].clone();
+        for connections_info in connections {
+            let id = parse_client_info(&connections_info)["id"].clone();
             if id != connection_id {
                 let mut client_kill_cmd = redis::cmd("CLIENT");
                 client_kill_cmd.arg("KILL").arg("ID").arg(id);


### PR DESCRIPTION
This change will ensure that failing management connections that were found in the periodic check will be reconnected automatically.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
