### PR TITLE
Fixed the parsing of cluster slots to sort the replicas in each view

### DIFF
--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -642,6 +642,11 @@ impl Slot {
     pub(crate) fn master(&self) -> &str {
         self.master.as_str()
     }
+
+    #[allow(dead_code)] // used in tests
+    pub fn replicas(&self) -> Vec<String> {
+        self.replicas.clone()
+    }
 }
 
 /// What type of node should a request be routed to, assuming read from replica is enabled.


### PR DESCRIPTION
Fixed the parsing of cluster slots to sort the replicas in each view to ensure accurate view comparisons based on hash.
Removed sorting of the slots order as Redis's implementation for CLUSTER SLOTS is being done by iterating through (0...16383) and therefore creating the returned slots map already in order. The only issue is that different nodes can hold a different order of the replicas in their view and this isn't being ordered in the server side.

Closes https://github.com/aws/glide-for-redis/issues/933 