### PR TITLE
Route unkeyed commands to a random node.

### DIFF
--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -339,6 +339,7 @@ impl ResponsePolicy {
 impl RoutingInfo {
     /// Returns true if the `cmd`` should be routed to all nodes.
     pub fn is_all_nodes(cmd: &[u8]) -> bool {
+        // TODO - this is a duplication of the match in `for_routable`. Should find some way to remove this.
         matches!(
             cmd,
             b"ACL SETUSER"
@@ -369,13 +370,18 @@ impl RoutingInfo {
         R: Routable + ?Sized,
     {
         let cmd = &r.command()?[..];
-        if Self::is_all_nodes(cmd) {
-            return Some(RoutingInfo::MultiNode((
-                MultipleNodeRoutingInfo::AllNodes,
-                ResponsePolicy::for_command(cmd),
-            )));
-        }
         match cmd {
+            b"ACL SETUSER" | b"ACL DELUSER" | b"ACL SAVE" | b"CLIENT SETNAME"
+            | b"CLIENT SETINFO" | b"SLOWLOG GET" | b"SLOWLOG LEN" | b"SLOWLOG RESET"
+            | b"CONFIG SET" | b"CONFIG RESETSTAT" | b"CONFIG REWRITE" | b"SCRIPT FLUSH"
+            | b"SCRIPT LOAD" | b"LATENCY RESET" | b"LATENCY GRAPH" | b"LATENCY HISTOGRAM"
+            | b"LATENCY HISTORY" | b"LATENCY DOCTOR" | b"LATENCY LATEST" => {
+                Some(RoutingInfo::MultiNode((
+                    MultipleNodeRoutingInfo::AllNodes,
+                    ResponsePolicy::for_command(cmd),
+                )))
+            }
+
             b"RANDOMKEY"
             | b"KEYS"
             | b"SCRIPT EXISTS"

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -434,6 +434,82 @@ impl RoutingInfo {
                 r.arg_idx(streams_position + 1)
                     .map(|key| RoutingInfo::for_key(cmd, key))
             }
+
+            // keyless commands with more arguments, whose arguments might be wrongly taken to be keys.
+            // TODO - double check these, in order to find better ways to route some of them.
+            b"ACL DRYRUN"
+            | b"ACL GENPASS"
+            | b"ACL GETUSER"
+            | b"ACL HELP"
+            | b"ACL LIST"
+            | b"ACL LOG"
+            | b"ACL USERS"
+            | b"ACL WHOAMI"
+            | b"AUTH"
+            | b"TIME"
+            | b"PUBSUB CHANNELS"
+            | b"PUBSUB NUMPAT"
+            | b"PUBSUB NUMSUB"
+            | b"PUBSUB SHARDCHANNELS"
+            | b"BGSAVE"
+            | b"WAITAOF"
+            | b"SAVE"
+            | b"LASTSAVE"
+            | b"CLIENT TRACKINGINFO"
+            | b"CLIENT PAUSE"
+            | b"CLIENT UNPAUSE"
+            | b"CLIENT UNBLOCK"
+            | b"CLIENT ID"
+            | b"CLIENT REPLY"
+            | b"CLIENT GETNAME"
+            | b"CLIENT GETREDIR"
+            | b"CLIENT INFO"
+            | b"CLIENT KILL"
+            | b"CLUSTER INFO"
+            | b"CLUSTER MEET"
+            | b"CLUSTER MYSHARDID"
+            | b"CLUSTER NODES"
+            | b"CLUSTER REPLICAS"
+            | b"CLUSTER RESET"
+            | b"CLUSTER SET-CONFIG-EPOCH"
+            | b"CLUSTER SLOTS"
+            | b"CLUSTER SHARDS"
+            | b"CLUSTER COUNT-FAILURE-REPORTS"
+            | b"CLUSTER KEYSLOT"
+            | b"COMMAND"
+            | b"COMMAND COUNT"
+            | b"COMMAND LIST"
+            | b"COMMAND GETKEYS"
+            | b"CONFIG GET"
+            | b"DEBUG"
+            | b"ECHO"
+            | b"READONLY"
+            | b"READWRITE"
+            | b"TFUNCTION LOAD"
+            | b"TFUNCTION DELETE"
+            | b"TFUNCTION LIST"
+            | b"TFCALL"
+            | b"TFCALLASYNC"
+            | b"MODULE LIST"
+            | b"MODULE LOAD"
+            | b"MODULE UNLOAD"
+            | b"MODULE LOADEX" => Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random)),
+
+            b"CLUSTER COUNTKEYSINSLOT"
+            | b"CLUSTER GETKEYSINSLOT"
+            | b"CLUSTER SETSLOT"
+            | b"CLUSTER DELSLOTS"
+            | b"CLUSTER DELSLOTSRANGE" => r
+                .arg_idx(2)
+                .and_then(|arg| std::str::from_utf8(arg).ok())
+                .and_then(|slot| slot.parse::<u16>().ok())
+                .map(|slot| {
+                    RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(Route::new(
+                        slot,
+                        SlotAddr::Master,
+                    )))
+                }),
+
             _ => match r.arg_idx(1) {
                 Some(key) => Some(RoutingInfo::for_key(cmd, key)),
                 None => Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random)),


### PR DESCRIPTION
Commands which have more arguments that aren't keys shouldn't be routed according to the hash of the additional arguments.
