### PR TITLE
Remove ordered_float from `Value`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,15 +1299,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-float"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1652,7 +1643,6 @@ dependencies = [
  "native-tls",
  "num-bigint",
  "once_cell",
- "ordered-float",
  "partial-io",
  "percent-encoding",
  "pin-project-lite",

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -97,7 +97,6 @@ num-bigint = "0.4.4"
 tracing = "0.1"
 futures-time = { version = "3.0.0", optional = true }
 arcstr = "1.1.5"
-ordered-float = "4.1.1"
 
 # Optional uuid support
 uuid = { version = "1.6.1", optional = true }

--- a/redis/src/parser.rs
+++ b/redis/src/parser.rs
@@ -315,7 +315,7 @@ where
                     b'~' => set(),
                     b'-' => error().map(Err),
                     b'_' => null(),
-                    b',' => double().map(|i| Ok(Value::Double(i.into()))),
+                    b',' => double().map(|i| Ok(Value::Double(i))),
                     b'#' => boolean().map(|b| Ok(Value::Boolean(b))),
                     b'!' => blob_error().map(Err),
                     b'=' => verbatim(),
@@ -515,7 +515,7 @@ mod tests {
     #[test]
     fn decode_resp3_double() {
         let val = parse_redis_value(b",1.23\r\n").unwrap();
-        assert_eq!(val, Value::Double(1.23.into()));
+        assert_eq!(val, Value::Double(1.23));
         let val = parse_redis_value(b",nan\r\n").unwrap();
         if let Value::Double(val) = val {
             assert!(val.is_sign_positive());
@@ -533,20 +533,20 @@ mod tests {
         }
         //Allow doubles in scientific E notation
         let val = parse_redis_value(b",2.67923e+8\r\n").unwrap();
-        assert_eq!(val, Value::Double(267923000.0.into()));
+        assert_eq!(val, Value::Double(267923000.0));
         let val = parse_redis_value(b",2.67923E+8\r\n").unwrap();
-        assert_eq!(val, Value::Double(267923000.0.into()));
+        assert_eq!(val, Value::Double(267923000.0));
         let val = parse_redis_value(b",-2.67923E+8\r\n").unwrap();
-        assert_eq!(val, Value::Double((-267923000.0).into()));
+        assert_eq!(val, Value::Double(-267923000.0));
         let val = parse_redis_value(b",2.1E-2\r\n").unwrap();
-        assert_eq!(val, Value::Double(0.021.into()));
+        assert_eq!(val, Value::Double(0.021));
 
         let val = parse_redis_value(b",-inf\r\n").unwrap();
-        assert_eq!(val, Value::Double((-f64::INFINITY).into()));
+        assert_eq!(val, Value::Double(-f64::INFINITY));
         let val = parse_redis_value(b",-inf\r\n").unwrap();
-        assert_eq!(val, Value::Double(f64::NEG_INFINITY.into()));
+        assert_eq!(val, Value::Double(f64::NEG_INFINITY));
         let val = parse_redis_value(b",inf\r\n").unwrap();
-        assert_eq!(val, Value::Double(f64::INFINITY.into()));
+        assert_eq!(val, Value::Double(f64::INFINITY));
     }
 
     #[test]

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -11,7 +11,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "ahash")]
 pub(crate) use ahash::{AHashMap as HashMap, AHashSet as HashSet};
 use num_bigint::BigInt;
-use ordered_float::OrderedFloat;
 #[cfg(not(feature = "ahash"))]
 pub(crate) use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
@@ -174,7 +173,7 @@ pub enum Value {
     /// Unordered set value from the server.
     Set(Vec<Value>),
     /// A floating number response from the server.
-    Double(OrderedFloat<f64>),
+    Double(f64),
     /// A boolean response from the server.
     Boolean(bool),
     /// First String is format and other is the string
@@ -1592,7 +1591,7 @@ macro_rules! from_redis_value_for_num_internal {
                 Ok(rv) => Ok(rv),
                 Err(_) => invalid_type_error!(v, "Could not convert from string."),
             },
-            Value::Double(val) => Ok(val.into_inner() as $t),
+            Value::Double(val) => Ok(val as $t),
             _ => invalid_type_error!(v, "Response type not convertible to numeric."),
         }
     }};

--- a/redis/tests/parser.rs
+++ b/redis/tests/parser.rs
@@ -1,6 +1,5 @@
 use std::{io, pin::Pin};
 
-use ordered_float::OrderedFloat;
 use redis::Value;
 use {
     futures::{
@@ -70,11 +69,7 @@ impl ::quickcheck::Arbitrary for ArbitraryValue {
             Value::SimpleString(ref status) => {
                 Box::new(status.shrink().map(Value::SimpleString).map(ArbitraryValue))
             }
-            Value::Double(i) => Box::new(
-                i.shrink()
-                    .map(|f| Value::Double(OrderedFloat(f)))
-                    .map(ArbitraryValue),
-            ),
+            Value::Double(i) => Box::new(i.shrink().map(Value::Double).map(ArbitraryValue)),
             Value::Boolean(i) => Box::new(i.shrink().map(Value::Boolean).map(ArbitraryValue)),
             Value::BigNumber(ref i) => {
                 Box::new(vec![ArbitraryValue(Value::BigNumber(i.clone()))].into_iter())


### PR DESCRIPTION
`ordered_float` was needed in order to derive the `Eq` trait, which is no longer in use. This allows us to align our code with redis-rs.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
