### PR TITLE
Fix cluster routing for OBJECT FREQ command

### DIFF
--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -397,7 +397,8 @@ fn base_routing(cmd: &[u8]) -> RouteBy {
         | b"XGROUP SETID"
         | b"XINFO CONSUMERS"
         | b"XINFO GROUPS"
-        | b"XINFO STREAM" => RouteBy::SecondArg,
+        | b"XINFO STREAM"
+        | b"OBJECT FREQ" => RouteBy::SecondArg,
 
         b"XREAD" | b"XREADGROUP" => RouteBy::StreamsIndex,
 

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -398,7 +398,10 @@ fn base_routing(cmd: &[u8]) -> RouteBy {
         | b"XINFO CONSUMERS"
         | b"XINFO GROUPS"
         | b"XINFO STREAM"
-        | b"OBJECT FREQ" => RouteBy::SecondArg,
+        | b"OBJECT ENCODING"
+        | b"OBJECT FREQ"
+        | b"OBJECT IDLETIME"
+        | b"OBJECT REFCOUNT" => RouteBy::SecondArg,
 
         b"XREAD" | b"XREADGROUP" => RouteBy::StreamsIndex,
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

This change fixes cluster routing for the OBJECT FREQ command. Without this change, integration tests for OBJECT FREQ fail in glide-for-redis .

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
