### PR TITLE
Add cluster scan functionality

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    timeout-minutes: 50    
+    timeout-minutes: 75    
     strategy:
       fail-fast: false
       matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,6 +997,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1660,6 +1666,8 @@ dependencies = [
  "sha1_smol",
  "socket2 0.5.6",
  "sscanf",
+ "strum",
+ "strum_macros",
  "tempfile",
  "tokio",
  "tokio-native-tls",
@@ -1891,6 +1899,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+
+[[package]]
 name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,6 +2088,25 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "subtle"

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test:
 	@echo "===================================================================="
 	@echo "Testing Connection Type UNIX SOCKETS"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=unix RUST_BACKTRACE=1 cargo test --locked -p redis --all-features -- --test-threads=1 --skip test_cluster --skip test_async_cluster --skip test_module
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=unix RUST_BACKTRACE=1 cargo test --locked -p redis --all-features -- --test-threads=1 --skip test_cluster --skip test_async_cluster --skip test_module --skip test_cluster_scan
 
 	@echo "===================================================================="
 	@echo "Testing async-std with Rustls"

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -25,6 +25,10 @@ bench = false
 ryu = "1.0"
 itoa = "1.0"
 
+# Strum is a set of macros and traits for working with enums and strings easier in Rust.
+strum = "0.26"
+strum_macros = "0.26"
+
 # This is a dependency that already exists in url
 percent-encoding = "2.1"
 

--- a/redis/src/cluster_async/connections_container.rs
+++ b/redis/src/cluster_async/connections_container.rs
@@ -65,7 +65,7 @@ impl<Connection> std::fmt::Display for ConnectionsMap<Connection> {
 
 pub(crate) struct ConnectionsContainer<Connection> {
     connection_map: HashMap<ArcStr, ClusterNode<Connection>>,
-    slot_map: SlotMap,
+    pub(crate) slot_map: SlotMap,
     read_from_replica_strategy: ReadFromReplicaStrategy,
     topology_hash: TopologyHash,
 }

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -133,27 +133,27 @@ where
             })
     }
 
-    // Special handling for 'SCAN' command, using cluster_scan
-    /// Perform a SCAN command on a Redis cluster, using scan state object in order to handle changes in topology
-    /// and make sure that all cluster is scanned.
+    // Special handling for `SCAN` command, using cluster_scan
+    /// Perform a `SCAN` command on a Redis cluster, using scan state object in order to handle changes in topology
+    /// and make sure that all keys that were in the cluster from start to end of the scan are scanned.
     /// In order to make sure all keys in the cluster scanned, topology refresh occurs more frequently and may affect performance.
     ///
     /// # Arguments
     ///
-    /// * `scan_state_rc` - A reference to the scan state, For initiating new scan send ScanStateRC::new(),
-    /// for each subsequent iteration use the returned ScanStateRC.
+    /// * `scan_state_rc` - A reference to the scan state, For initiating new scan send [`ScanStateRC::new()`],
+    /// for each subsequent iteration use the returned [`ScanStateRC`].
     /// * `match_pattern` - An optional match pattern of requested keys.
     /// * `count` - An optional count of keys requested,
     /// the amount returned can vary and not obligated to return exactly count.
-    /// * `object_type` - An optional ObjectType enum of requested key redis type.
+    /// * `object_type` - An optional [`ObjectType`] enum of requested key redis type.
     ///
     /// # Returns
     ///
-    /// A ScanStateRC for the updated state of the scan and the vector of keys that were found in the scan.
+    /// A [`ScanStateRC`] for the updated state of the scan and the vector of keys that were found in the scan.
     /// structure of returned value:
     /// `Ok((ScanStateRC, Vec<Value>))`
     ///
-    /// When the scan is finished ScanStateRC will be None, and can be checked by calling scan_state_wrapper.is_finished().
+    /// When the scan is finished [`ScanStateRC`] will be None, and can be checked by calling `scan_state_wrapper.is_finished()`.
     ///
     /// # Example
     /// ```rust,no_run
@@ -181,7 +181,7 @@ where
     ///         }
     ///     keys     
     ///     }
-    /// ````
+    /// ```
     pub async fn cluster_scan(
         &mut self,
         scan_state_rc: ScanStateRC,

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -137,7 +137,7 @@ where
     ///
     /// # Arguments
     ///
-    /// * `scan_state_ref` - A reference to the scan state, For initiating new scan send ScanStateCursor::new(),
+    /// * `scan_state_cursor` - A reference to the scan state, For initiating new scan send ScanStateCursor::new(),
     /// for each iteration after the first use the returned RefCell.
     /// * `match_pattern` - An optional match pattern of wanted keys.
     /// * `count` - An optional count of keys wanted,
@@ -181,13 +181,13 @@ where
     /// ````
     pub async fn cluster_scan(
         &mut self,
-        scan_state_ref: ScanStateCursor,
+        scan_state_cursor: ScanStateCursor,
         match_pattern: Option<&str>,
         count: Option<usize>,
         object_type: Option<ObjectType>,
     ) -> RedisResult<(ScanStateCursor, Vec<Value>)> {
         let cluster_scan_args = ClusterScanArgs::new(
-            scan_state_ref,
+            scan_state_cursor,
             match_pattern.map(|s| s.to_string()),
             count,
             object_type,

--- a/redis/src/cluster_slotmap.rs
+++ b/redis/src/cluster_slotmap.rs
@@ -34,7 +34,6 @@ pub(crate) enum ReadFromReplicaStrategy {
 pub(crate) struct SlotMap {
     pub(crate) slots: BTreeMap<u16, SlotMapValue>,
     read_from_replica: ReadFromReplicaStrategy,
-    pub(crate) all_slots_covered: bool,
 }
 
 fn get_address_from_slot(
@@ -62,7 +61,6 @@ impl SlotMap {
         let mut this = Self {
             slots: BTreeMap::new(),
             read_from_replica,
-            all_slots_covered: true,
         };
         this.slots.extend(
             slots
@@ -130,14 +128,12 @@ impl SlotMap {
 
     // Returns the slots that are assigned to the given address.
     pub(crate) fn get_slots_of_node(&self, node_address: &str) -> Vec<u16> {
+        let node_address = node_address.to_string();
         self.slots
             .iter()
             .filter_map(|(end, slot_value)| {
                 if slot_value.addrs.primary == node_address
-                    || slot_value
-                        .addrs
-                        .replicas
-                        .contains(&node_address.to_string())
+                    || slot_value.addrs.replicas.contains(&node_address)
                 {
                     Some(slot_value.start..(*end + 1))
                 } else {
@@ -163,14 +159,6 @@ impl SlotMap {
                 None
             }
         })
-    }
-
-    pub(crate) fn set_all_slots_covered(&mut self, all_slots_covered: bool) {
-        self.all_slots_covered = all_slots_covered;
-    }
-
-    pub(crate) fn is_all_slots_covered(&self) -> bool {
-        self.all_slots_covered
     }
 }
 

--- a/redis/src/commands/cluster_scan.rs
+++ b/redis/src/commands/cluster_scan.rs
@@ -1,0 +1,495 @@
+use crate::aio::ConnectionLike;
+use crate::cluster_async::{ClusterConnInner, Connect, Core, InnerCore};
+use crate::cluster_routing::SlotAddr;
+use crate::cluster_topology::SLOT_SIZE;
+use crate::{cmd, from_redis_value, Cmd, ErrorKind, RedisError, RedisResult, Value};
+use async_trait::async_trait;
+use std::sync::Arc;
+
+/// This module contains the implementation of scanning operations in a Redis cluster.
+///
+/// The `ClusterScanArgs` struct represents the arguments for a cluster scan operation,
+/// including the scan state reference, match pattern, count, and object type.
+///
+/// The `ScanStateCursor` struct is a wrapper for managing the state of a scan operation in a cluster.
+/// It holds a reference to the scan state and provides methods for accessing the state.
+///
+/// The `ClusterInScan` trait defines the methods for interacting with a Redis cluster during scanning,
+/// including retrieving address information, refreshing slot mapping, and routing commands to specific addresss.
+///
+/// The `ScanState` struct represents the state of a scan operation in a Redis cluster.
+/// It holds information about the current scan state, including the cursor position, scanned slots map,
+/// address being scanned, and address's epoch.
+
+const BITS_PER_U64: usize = u64::BITS as usize;
+const NUM_OF_SLOTS: usize = SLOT_SIZE as usize;
+const BITS_ARRAY_SIZE: usize = NUM_OF_SLOTS / BITS_PER_U64;
+const END_OF_SCAN: u16 = NUM_OF_SLOTS as u16 + 1;
+type SlotsBitsArray = [u64; BITS_ARRAY_SIZE];
+
+#[derive(PartialEq, Debug, Clone)]
+pub(crate) struct ScanState {
+    // the real cursor in the scan operation
+    cursor: u64,
+    // a map of the slots that have been scanned
+    scanned_slots_map: SlotsBitsArray,
+    // the address that is being scanned currently, based on the next slot set to 0 in the scanned_slots_map, and the address "own" the slot
+    // in the SlotMap
+    pub(crate) address_in_scan: String,
+    // epoch represent the version of the address, when a failover happens or slots migrate in the epoch will be updated to +1
+    address_epoch: u64,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ClusterScanArgs {
+    pub(crate) scan_state_cursor: ScanStateCursor,
+    match_pattern: Option<String>,
+    count: Option<usize>,
+    object_type: Option<ObjectType>,
+}
+
+#[derive(Debug, Clone)]
+/// Represents the type of an object in Redis.
+pub enum ObjectType {
+    /// Represents a string object in Redis.
+    STRING,
+    /// Represents a list object in Redis.
+    LIST,
+    /// Represents a set object in Redis.
+    SET,
+    /// Represents a sorted set object in Redis.
+    ZSET,
+    /// Represents a hash object in Redis.
+    HASH,
+}
+
+impl std::fmt::Display for ObjectType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            ObjectType::STRING => write!(f, "string"),
+            ObjectType::LIST => write!(f, "list"),
+            ObjectType::SET => write!(f, "set"),
+            ObjectType::ZSET => write!(f, "zset"),
+            ObjectType::HASH => write!(f, "hash"),
+        }
+    }
+}
+
+impl ClusterScanArgs {
+    pub(crate) fn new(
+        scan_state_cursor: ScanStateCursor,
+        match_pattern: Option<String>,
+        count: Option<usize>,
+        object_type: Option<ObjectType>,
+    ) -> Self {
+        Self {
+            scan_state_cursor,
+            match_pattern,
+            count,
+            object_type,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+/// A wrapper struct for managing the state of a scan operation in a cluster.
+pub struct ScanStateCursor {
+    scan_state_ref: Arc<Option<ScanState>>,
+}
+
+impl ScanStateCursor {
+    /// Creates a new instance of `ScanStateCursor` from a given `ScanState`.
+    fn from_scan_state(scan_state: &ScanState) -> Self {
+        Self {
+            scan_state_ref: Arc::new(Some(scan_state.clone())),
+        }
+    }
+
+    /// Creates a new instance of `ScanStateCursor`.
+    ///
+    /// This method initializes the `ScanStateCursor` with a reference to a `ScanState` that is initially set to `None`.
+    /// An empty ScanState is equivilant to a 0 cursor.
+    pub fn new() -> Self {
+        Self {
+            scan_state_ref: Arc::new(None),
+        }
+    }
+
+    /// Returns `true` if the scan state is empty, indicating that the scan operation has finished or has not started.
+    pub fn is_none(&self) -> bool {
+        self.scan_state_ref.is_none()
+    }
+
+    /// Returns a clone of the scan state, if it exist.
+    pub(crate) fn get_state_from_wrraper(&self) -> Option<ScanState> {
+        if self.is_none() {
+            None
+        } else {
+            self.scan_state_ref.as_ref().clone()
+        }
+    }
+}
+
+/// This trait defines the methods for interacting with a Redis cluster during scanning.
+#[async_trait]
+pub(crate) trait ClusterInScan {
+    /// Retrieves the address address associated with a given slot in the cluster.
+    async fn get_address_by_slot(&self, slot: u16) -> RedisResult<String>;
+
+    /// Retrieves the epoch of a given address in the cluster.
+    async fn get_address_epoch(&self, address: &str) -> Result<u64, RedisError>;
+
+    /// Retrieves the slots assigned to a given address in the cluster.
+    async fn get_slots_of_address(&self, address: &str) -> Vec<u16>;
+
+    /// Refreshes the slot mapping of the cluster.
+    async fn refresh_slots(&self) -> RedisResult<()>;
+
+    /// Routes a Redis command to a specific address in the cluster.
+    async fn route_command(&self, cmd: &Cmd, address: &str) -> RedisResult<Value>;
+
+    /// Chaeck if all slots are covered by the cluster
+    async fn is_all_slots_covered(&self) -> bool;
+}
+
+/// Represents the state of a scan operation in a Redis cluster.
+///
+/// This struct holds information about the current scan state, including the cursor position,
+/// the scanned slots map, the address being scanned, and the address's epoch.
+impl ScanState {
+    /// Create a new instance of ScanState.
+    ///
+    /// # Arguments
+    ///
+    /// * `cursor` - The cursor position.
+    /// * `scanned_slots_map` - The scanned slots map.
+    /// * `address_in_scan` - The address being scanned.
+    /// * `address_epoch` - The epoch of the address being scanned.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of ScanState.
+    pub fn create(
+        cursor: u64,
+        scanned_slots_map: SlotsBitsArray,
+        address_in_scan: String,
+        address_epoch: u64,
+    ) -> Self {
+        Self {
+            cursor,
+            scanned_slots_map,
+            address_in_scan,
+            address_epoch,
+        }
+    }
+
+    /// Initiate a scan operation by creating a new ScanState.
+    ///
+    /// This method creates a new ScanState with the initial values for a scan operation.
+    ///
+    /// # Arguments
+    ///
+    /// * `connection` - The connection to the Redis cluster.
+    ///
+    /// # Returns
+    ///
+    /// The initial ScanState.
+    pub(crate) async fn initiate_scan<C: ClusterInScan + ?Sized>(
+        connection: &C,
+    ) -> RedisResult<ScanState> {
+        let new_scanned_slots_map: SlotsBitsArray = [0; BITS_ARRAY_SIZE];
+        let new_cursor = 0;
+        let address_in_scan = connection.get_address_by_slot(0).await;
+        match address_in_scan {
+            Ok(address) => {
+                let address_epoch = connection.get_address_epoch(&address).await.unwrap_or(0);
+                Ok(ScanState::create(
+                    new_cursor,
+                    new_scanned_slots_map,
+                    address,
+                    address_epoch,
+                ))
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Get the next slot that hasn't been scanned.
+    ///
+    /// This method iterates over the scanned slots map and finds the next slot that is set to 0.
+    ///
+    /// # Arguments
+    ///
+    /// * `scanned_slots_map` - The scanned slots map.
+    ///
+    /// # Returns
+    ///
+    /// The next slot that hasn't been scanned, or `None` if all slots have been scanned.
+    pub fn get_next_slot(&self, scanned_slots_map: &SlotsBitsArray) -> Option<u16> {
+        let all_slots_scanned = scanned_slots_map.iter().all(|&word| word == u64::MAX);
+        if all_slots_scanned {
+            return Some(END_OF_SCAN);
+        }
+        for (i, slot) in scanned_slots_map.iter().enumerate() {
+            let mut mask = 1;
+            for j in 0..BITS_PER_U64 {
+                if (slot & mask) == 0 {
+                    return Some((i * BITS_PER_U64 + j) as u16);
+                }
+                mask <<= 1;
+            }
+        }
+        None
+    }
+
+    /// Update the next address to be scanned without updating the scanned slots map.
+    /// This method is used when the address epoch has changed and we can't know which slots are new or when slots are missing.
+    /// In this case we will skip updating the scanned_slots_map and will just update the address and the cursor.
+    ///
+    /// # Arguments
+    ///
+    /// * `connection` - The connection to the Redis cluster.
+    ///
+    /// # Returns
+    ///
+    /// The updated ScanState.
+    pub(crate) async fn update_scan_state_without_updating_scanned_map<
+        C: ClusterInScan + ?Sized,
+    >(
+        &self,
+        connection: &C,
+    ) -> RedisResult<ScanState> {
+        let next_slot = self.get_next_slot(&self.scanned_slots_map).unwrap();
+        let new_address = if next_slot == END_OF_SCAN {
+            Ok("".to_string())
+        } else {
+            connection.get_address_by_slot(next_slot).await
+        };
+        match new_address {
+            Ok(address) => {
+                let new_epoch = connection.get_address_epoch(&address).await.unwrap_or(0);
+                let new_cursor = 0;
+                Ok(ScanState::create(
+                    new_cursor,
+                    self.scanned_slots_map,
+                    address,
+                    new_epoch,
+                ))
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Update the next address to be scanned.
+    ///
+    /// This method updates the scan state by updating the scanned slots map, determining the next slot to be scanned,
+    /// retrieving the address for that slot and the epoch of that address, and creating a new ScanState.
+    ///
+    /// # Arguments
+    ///
+    /// * `connection` - The connection to the Redis cluster.
+    ///
+    /// # Returns
+    ///
+    /// The updated ScanState.
+    async fn update_scan_state_and_get_next_address<C: ClusterInScan + ?Sized>(
+        &mut self,
+        connection: &C,
+    ) -> RedisResult<ScanState> {
+        let _ = connection.refresh_slots().await;
+        let mut scanned_slots_map = self.scanned_slots_map;
+        // If the address epoch changed it mean that some slots in the address are new, so we cant know which slots been there from the begining and which are new, or out and in later.
+        // In this case we will skip updating the scanned_slots_map and will just update the address and the cursor
+        let new_address_epoch = connection
+            .get_address_epoch(&self.address_in_scan)
+            .await
+            .unwrap_or(0);
+        if new_address_epoch != self.address_epoch {
+            return self
+                .update_scan_state_without_updating_scanned_map(connection)
+                .await;
+        }
+        // If epoch wasn't changed, the slots owned by the address after the refresh are all valid as slots that been scanned
+        // So we will update the scanned_slots_map with the slots owned by the address
+        let slots_scanned = connection.get_slots_of_address(&self.address_in_scan).await;
+        for slot in slots_scanned {
+            let slot_index = slot as usize / BITS_PER_U64;
+            let slot_bit = slot as usize % BITS_PER_U64;
+            scanned_slots_map[slot_index] |= 1 << slot_bit;
+        }
+        // Get the next address to scan and its param base on the next slot set to 0 in the scanned_slots_map
+        let next_slot = self.get_next_slot(&scanned_slots_map).unwrap();
+        let new_address = if next_slot == END_OF_SCAN {
+            Ok("".to_string())
+        } else {
+            connection.get_address_by_slot(next_slot).await
+        };
+        match new_address {
+            Ok(new_address) => {
+                let new_epoch = connection
+                    .get_address_epoch(&new_address)
+                    .await
+                    .unwrap_or(0);
+                let new_cursor = 0;
+                Ok(ScanState::create(
+                    new_cursor,
+                    scanned_slots_map,
+                    new_address,
+                    new_epoch,
+                ))
+            }
+            Err(err) => Err(err),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_creation_of_empty_scan_wrapper() {
+        let scan_state_wrapper = ScanStateCursor::new();
+        assert!(scan_state_wrapper.is_none());
+    }
+
+    #[test]
+    fn test_creation_of_scan_state_wrapper_from() {
+        let scan_state = ScanState {
+            cursor: 0,
+            scanned_slots_map: [0; BITS_ARRAY_SIZE],
+            address_in_scan: String::from("address1"),
+            address_epoch: 1,
+        };
+
+        let scan_state_wrapper = ScanStateCursor::from_scan_state(&scan_state);
+        assert!(!scan_state_wrapper.is_none());
+    }
+
+    #[test]
+    // Test the get_next_slot method
+    fn test_scan_state_get_next_slot() {
+        let scanned_slots_map: SlotsBitsArray = [0; BITS_ARRAY_SIZE];
+        let scan_state = ScanState {
+            cursor: 0,
+            scanned_slots_map,
+            address_in_scan: String::from("address1"),
+            address_epoch: 1,
+        };
+        let next_slot = scan_state.get_next_slot(&scanned_slots_map);
+        assert_eq!(next_slot, Some(0));
+        // Set the first slot to 1
+        let mut scanned_slots_map: SlotsBitsArray = [0; BITS_ARRAY_SIZE];
+        scanned_slots_map[0] = 1;
+        let scan_state = ScanState {
+            cursor: 0,
+            scanned_slots_map,
+            address_in_scan: String::from("address1"),
+            address_epoch: 1,
+        };
+        let next_slot = scan_state.get_next_slot(&scanned_slots_map);
+        assert_eq!(next_slot, Some(1));
+    }
+    // Create a mock connection
+    struct MockConnection;
+    #[async_trait]
+    impl ClusterInScan for MockConnection {
+        async fn get_address_by_slot(&self, _slot: u16) -> RedisResult<String> {
+            Ok("mock_address".to_string())
+        }
+        async fn get_address_epoch(&self, _address: &str) -> Result<u64, RedisError> {
+            Ok(0)
+        }
+        async fn get_slots_of_address(&self, address: &str) -> Vec<u16> {
+            if address == "mock_address" {
+                vec![3, 4, 5]
+            } else {
+                vec![0, 1, 2]
+            }
+        }
+        async fn refresh_slots(&self) -> RedisResult<()> {
+            Ok(())
+        }
+        async fn route_command(&self, _: &Cmd, _: &str) -> RedisResult<Value> {
+            unimplemented!()
+        }
+        async fn is_all_slots_covered(&self) -> bool {
+            true
+        }
+    }
+    // Test the initiate_scan function
+    #[tokio::test]
+    async fn test_initiate_scan() {
+        let connection = MockConnection;
+        let scan_state = ScanState::initiate_scan(&connection).await.unwrap();
+
+        // Assert that the scan state is initialized correctly
+        assert_eq!(scan_state.cursor, 0);
+        assert_eq!(scan_state.scanned_slots_map, [0; BITS_ARRAY_SIZE]);
+        assert_eq!(scan_state.address_in_scan, "mock_address");
+        assert_eq!(scan_state.address_epoch, 0);
+    }
+
+    // Test the get_next_slot function
+    #[test]
+    fn test_get_next_slot() {
+        let scan_state = ScanState {
+            cursor: 0,
+            scanned_slots_map: [0; BITS_ARRAY_SIZE],
+            address_in_scan: "".to_string(),
+            address_epoch: 0,
+        };
+        // Test when all first bits of each u6 are set to 1, the next slots should be 1
+        let scanned_slots_map: SlotsBitsArray = [1; BITS_ARRAY_SIZE];
+        let next_slot = scan_state.get_next_slot(&scanned_slots_map);
+        assert_eq!(next_slot, Some(1));
+
+        // Test when all slots are scanned, the next slot should be 0
+        let scanned_slots_map: SlotsBitsArray = [u64::MAX; BITS_ARRAY_SIZE];
+        let next_slot = scan_state.get_next_slot(&scanned_slots_map);
+        assert_eq!(next_slot, Some(16385));
+
+        // Test when first, second, fourth, sixth and eighth slots scanned, the next slot should be 2
+        let mut scanned_slots_map: SlotsBitsArray = [0; BITS_ARRAY_SIZE];
+        scanned_slots_map[0] = 171; // 10101011
+        let next_slot = scan_state.get_next_slot(&scanned_slots_map);
+        assert_eq!(next_slot, Some(2));
+    }
+
+    // Test the update_scan_state_and_get_next_address function
+    #[tokio::test]
+    async fn test_update_scan_state_and_get_next_address() {
+        let connection = MockConnection;
+        let scan_state = ScanState::initiate_scan(&connection).await;
+        let updated_scan_state = scan_state
+            .unwrap()
+            .update_scan_state_and_get_next_address(&connection)
+            .await
+            .unwrap();
+
+        // cursor should be reset to 0
+        assert_eq!(updated_scan_state.cursor, 0);
+
+        // address_in_scan should be updated to the new address
+        assert_eq!(updated_scan_state.address_in_scan, "mock_address");
+
+        // address_epoch should be updated to the new address epoch
+        assert_eq!(updated_scan_state.address_epoch, 0);
+    }
+
+    #[tokio::test]
+    async fn test_update_scan_state_without_updating_scanned_map() {
+        let connection = MockConnection;
+        let scan_state = ScanState::create(0, [0; BITS_ARRAY_SIZE], "address".to_string(), 0);
+        let scanned_slots_map = scan_state.scanned_slots_map;
+        let updated_scan_state = scan_state
+            .update_scan_state_without_updating_scanned_map(&connection)
+            .await
+            .unwrap();
+        assert_eq!(updated_scan_state.scanned_slots_map, scanned_slots_map);
+        assert_eq!(updated_scan_state.cursor, 0);
+        assert_eq!(updated_scan_state.address_in_scan, "mock_address");
+        assert_eq!(updated_scan_state.address_epoch, 0);
+    }
+}

--- a/redis/src/commands/cluster_scan.rs
+++ b/redis/src/commands/cluster_scan.rs
@@ -9,16 +9,16 @@ use strum_macros::Display;
 
 /// This module contains the implementation of scanning operations in a Redis cluster.
 ///
-/// The `ClusterScanArgs` struct represents the arguments for a cluster scan operation,
+/// The [`ClusterScanArgs`] struct represents the arguments for a cluster scan operation,
 /// including the scan state reference, match pattern, count, and object type.
 ///
-/// The `ScanStateRC` struct is a wrapper for managing the state of a scan operation in a cluster.
+/// The [[`ScanStateRC`]] struct is a wrapper for managing the state of a scan operation in a cluster.
 /// It holds a reference to the scan state and provides methods for accessing the state.
 ///
-/// The `ClusterInScan` trait defines the methods for interacting with a Redis cluster during scanning,
+/// The [[`ClusterInScan`]] trait defines the methods for interacting with a Redis cluster during scanning,
 /// including retrieving address information, refreshing slot mapping, and routing commands to specific address.
 ///
-/// The `ScanState` struct represents the state of a scan operation in a Redis cluster.
+/// The [[`ScanState`]] struct represents the state of a scan operation in a Redis cluster.
 /// It holds information about the current scan state, including the cursor position, scanned slots map,
 /// address being scanned, and address's epoch.
 
@@ -85,7 +85,7 @@ pub struct ScanStateRC {
 }
 
 impl ScanStateRC {
-    /// Creates a new instance of `ScanStateRC` from a given `ScanState`.
+    /// Creates a new instance of [`ScanStateRC`] from a given [`ScanState`].
     fn from_scan_state(scan_state: ScanState) -> Self {
         Self {
             scan_state_rc: Arc::new(Some(scan_state)),
@@ -93,9 +93,9 @@ impl ScanStateRC {
         }
     }
 
-    /// Creates a new instance of `ScanStateRC`.
+    /// Creates a new instance of [`ScanStateRC`].
     ///
-    /// This method initializes the `ScanStateRC` with a reference to a `ScanState` that is initially set to `None`.
+    /// This method initializes the [`ScanStateRC`] with a reference to a [`ScanState`] that is initially set to `None`.
     /// An empty ScanState is equivalent to a 0 cursor.
     pub fn new() -> Self {
         Self {
@@ -103,7 +103,7 @@ impl ScanStateRC {
             status: ScanStateStage::Initiating,
         }
     }
-    /// create a new instance of `ScanStateRC` with finished state and empty scan state.
+    /// create a new instance of [`ScanStateRC`] with finished state and empty scan state.
     fn create_finished() -> Self {
         Self {
             scan_state_rc: Arc::new(None),
@@ -227,7 +227,7 @@ impl ScanState {
     }
 
     /// Get the next slot to be scanned based on the scanned slots map.
-    /// If all slots have been scanned, the method returns `END_OF_SCAN`.
+    /// If all slots have been scanned, the method returns [`END_OF_SCAN`].
     fn get_next_slot(&self, scanned_slots_map: &SlotsBitsArray) -> Option<u16> {
         let all_slots_scanned = scanned_slots_map.iter().all(|&word| word == u64::MAX);
         if all_slots_scanned {
@@ -329,7 +329,7 @@ impl ScanState {
     }
 }
 
-// Implement the `ClusterInScan` trait for `InnerCore` of async cluster connection.
+// Implement the [`ClusterInScan`] trait for [`InnerCore`] of async cluster connection.
 #[async_trait]
 impl<C> ClusterInScan for Core<C>
 where
@@ -377,7 +377,7 @@ where
 }
 
 /// Perform a cluster scan operation.
-/// This function performs a scan operation in a Redis cluster using the given `ClusterInScan` connection.
+/// This function performs a scan operation in a Redis cluster using the given [`ClusterInScan`] connection.
 /// It scans the cluster for keys based on the given `ClusterScanArgs` arguments.
 /// The function returns a tuple containing the new scan state cursor and the keys found in the scan operation.
 /// If the scan operation fails, an error is returned.

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -13,6 +13,15 @@ mod macros;
 #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 mod json;
 
+#[cfg(feature = "cluster-async")]
+pub use cluster_scan::ScanStateCursor;
+
+#[cfg(feature = "cluster-async")]
+pub(crate) mod cluster_scan;
+
+#[cfg(feature = "cluster-async")]
+pub use cluster_scan::ObjectType;
+
 #[cfg(feature = "json")]
 pub use json::JsonCommands;
 

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -14,7 +14,7 @@ mod macros;
 mod json;
 
 #[cfg(feature = "cluster-async")]
-pub use cluster_scan::ScanStateCursor;
+pub use cluster_scan::ScanStateRC;
 
 #[cfg(feature = "cluster-async")]
 pub(crate) mod cluster_scan;

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -449,6 +449,12 @@ pub mod cluster;
 #[cfg_attr(docsrs, doc(cfg(feature = "cluster")))]
 mod cluster_slotmap;
 
+#[cfg(feature = "cluster-async")]
+pub use crate::commands::ScanStateCursor;
+
+#[cfg(feature = "cluster-async")]
+pub use crate::commands::ObjectType;
+
 #[cfg(feature = "cluster")]
 mod cluster_client;
 

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -450,7 +450,7 @@ pub mod cluster;
 mod cluster_slotmap;
 
 #[cfg(feature = "cluster-async")]
-pub use crate::commands::ScanStateCursor;
+pub use crate::commands::ScanStateRC;
 
 #[cfg(feature = "cluster-async")]
 pub use crate::commands::ObjectType;

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -143,6 +143,9 @@ pub enum ErrorKind {
     /// Redis Servers prior to v6.0.0 doesn't support RESP3.
     /// Try disabling resp3 option
     RESP3NotSupported,
+
+    /// Not all slots are covered by the cluster
+    NotAllSlotsCovered,
 }
 
 #[derive(PartialEq, Debug)]
@@ -877,6 +880,7 @@ impl RedisError {
             ErrorKind::Serialize => "serializing",
             ErrorKind::RESP3NotSupported => "resp3 is not supported by server",
             ErrorKind::ParseError => "parse error",
+            ErrorKind::NotAllSlotsCovered => "not all slots are covered",
         }
     }
 
@@ -1061,6 +1065,7 @@ impl RedisError {
                 },
                 _ => RetryMethod::RetryImmediately,
             },
+            ErrorKind::NotAllSlotsCovered => RetryMethod::NoRetry,
         }
     }
 }

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -18,6 +18,8 @@ use redis::cluster_async::Connect;
 use redis::ConnectionInfo;
 use redis::ProtocolVersion;
 use redis::PushInfo;
+use redis::RedisResult;
+use redis::Value;
 use tempfile::TempDir;
 
 use crate::support::{build_keys_and_certs_for_tls, Module};
@@ -501,7 +503,7 @@ impl TestClusterContext {
     ) {
         let slots_ranges_of_node_id = slot_distribution[0].3.clone();
 
-        let mut conn = self.async_connection().await;
+        let mut conn = self.async_connection(None).await;
 
         let from = slot_distribution[0].clone();
         let target = slot_distribution[1].clone();
@@ -744,7 +746,7 @@ impl TestClusterContext {
     }
 
     pub async fn get_cluster_nodes(&self) -> String {
-        let mut conn = self.async_connection().await;
+        let mut conn = self.async_connection(None).await;
         let mut cmd = redis::cmd("CLUSTER");
         cmd.arg("NODES");
         let res: RedisResult<Value> = conn
@@ -756,7 +758,7 @@ impl TestClusterContext {
 
     pub async fn wait_for_fail_to_finish(&self, route: &RoutingInfo) -> RedisResult<()> {
         for _ in 0..500 {
-            let mut conn = self.async_connection().await;
+            let mut conn = self.async_connection(None).await;
             let cmd = redis::cmd("PING");
             let res: RedisResult<Value> = conn.route_command(&cmd, route.clone()).await;
             if res.is_err() {
@@ -773,7 +775,7 @@ impl TestClusterContext {
     pub async fn wait_for_connection_is_ready(&self, route: &RoutingInfo) -> RedisResult<()> {
         let mut i = 1;
         while i < 1000 {
-            let mut conn = self.async_connection().await;
+            let mut conn = self.async_connection(None).await;
             let cmd = redis::cmd("PING");
             let res: RedisResult<Value> = conn.route_command(&cmd, route.clone()).await;
             if res.is_ok() {

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -7,6 +7,10 @@ use std::process;
 use std::thread::sleep;
 use std::time::Duration;
 
+use redis::cluster_routing::RoutingInfo;
+use redis::cluster_routing::SingleNodeRoutingInfo;
+use redis::from_redis_value;
+
 #[cfg(feature = "cluster-async")]
 use redis::aio::ConnectionLike;
 #[cfg(feature = "cluster-async")]
@@ -468,5 +472,319 @@ impl TestClusterContext {
     pub fn get_version(&self) -> super::Version {
         let mut conn = self.connection();
         super::get_version(&mut conn)
+    }
+
+    pub fn get_node_ids(&self) -> Vec<String> {
+        let mut conn = self.connection();
+        let nodes: Vec<String> = redis::cmd("CLUSTER")
+            .arg("NODES")
+            .query::<String>(&mut conn)
+            .unwrap()
+            .split('\n')
+            .map(|s| s.to_string())
+            .collect();
+        let node_ids: Vec<String> = nodes
+            .iter()
+            .map(|node| node.split(' ').next().unwrap().to_string())
+            .collect();
+        node_ids
+            .iter()
+            .filter(|id| !id.is_empty())
+            .cloned()
+            .collect()
+    }
+
+    // Migrate half the slots from one node to another
+    pub async fn migrate_slots_from_node_to_another(
+        &self,
+        slot_distribution: Vec<(String, String, String, Vec<Vec<u16>>)>,
+    ) {
+        let slots_ranges_of_node_id = slot_distribution[0].3.clone();
+
+        let mut conn = self.async_connection().await;
+
+        let from = slot_distribution[0].clone();
+        let target = slot_distribution[1].clone();
+
+        let from_node_id = from.0.clone();
+        let target_node_id = target.0.clone();
+
+        let from_route = RoutingInfo::SingleNode(SingleNodeRoutingInfo::ByAddress {
+            host: from.1.clone(),
+            port: from.2.clone().parse::<u16>().unwrap(),
+        });
+        let target_route = RoutingInfo::SingleNode(SingleNodeRoutingInfo::ByAddress {
+            host: target.1.clone(),
+            port: target.2.clone().parse::<u16>().unwrap(),
+        });
+
+        // Migrate the slots
+        for range in slots_ranges_of_node_id {
+            let mut slots_of_nodes: std::ops::Range<u16> = range[0]..range[1];
+            let number_of_slots = range[1] - range[0] + 1;
+            // Migrate half the slots
+            for _i in 0..(number_of_slots as f64 / 2.0).floor() as usize {
+                let slot = slots_of_nodes.next().unwrap();
+                // Set the nodes to MIGRATING and IMPORTING
+                let mut set_cmd = redis::cmd("CLUSTER");
+                set_cmd
+                    .arg("SETSLOT")
+                    .arg(slot)
+                    .arg("IMPORTING")
+                    .arg(from_node_id.clone());
+                let result: RedisResult<Value> =
+                    conn.route_command(&set_cmd, target_route.clone()).await;
+                match result {
+                    Ok(_) => {}
+                    Err(err) => {
+                        println!(
+                            "Failed to set slot {} to IMPORTING with error {}",
+                            slot, err
+                        );
+                    }
+                }
+                let mut set_cmd = redis::cmd("CLUSTER");
+                set_cmd
+                    .arg("SETSLOT")
+                    .arg(slot)
+                    .arg("MIGRATING")
+                    .arg(target_node_id.clone());
+                let result: RedisResult<Value> =
+                    conn.route_command(&set_cmd, from_route.clone()).await;
+                match result {
+                    Ok(_) => {}
+                    Err(err) => {
+                        println!(
+                            "Failed to set slot {} to MIGRATING with error {}",
+                            slot, err
+                        );
+                    }
+                }
+                // Get a key from the slot
+                let mut get_key_cmd = redis::cmd("CLUSTER");
+                get_key_cmd.arg("GETKEYSINSLOT").arg(slot).arg(1);
+                let result: RedisResult<Value> =
+                    conn.route_command(&get_key_cmd, from_route.clone()).await;
+                let vec_string_result: Vec<String> = match result {
+                    Ok(val) => {
+                        let val: Vec<String> = from_redis_value(&val).unwrap();
+                        val
+                    }
+                    Err(err) => {
+                        println!("Failed to get keys in slot {}: {:?}", slot, err);
+                        continue;
+                    }
+                };
+                if vec_string_result.is_empty() {
+                    continue;
+                }
+                let key = vec_string_result[0].clone();
+                // Migrate the key, which will make the whole slot to move
+                let mut migrate_cmd = redis::cmd("MIGRATE");
+                migrate_cmd
+                    .arg(target.1.clone())
+                    .arg(target.2.clone())
+                    .arg(key.clone())
+                    .arg(0)
+                    .arg(5000);
+                let result: RedisResult<Value> =
+                    conn.route_command(&migrate_cmd, from_route.clone()).await;
+
+                match result {
+                    Ok(Value::Okay) => {}
+                    Ok(Value::SimpleString(str)) => {
+                        if str != "NOKEY" {
+                            println!(
+                                "Failed to migrate key {} to target node with status {}",
+                                key, str
+                            );
+                        } else {
+                            println!("Key {} does not exist", key);
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(err) => {
+                        println!(
+                            "Failed to migrate key {} to target node with error {}",
+                            key, err
+                        );
+                    }
+                }
+                // Tell the source and target nodes to propagate the slot change to the cluster
+                let mut setslot_cmd = redis::cmd("CLUSTER");
+                setslot_cmd
+                    .arg("SETSLOT")
+                    .arg(slot)
+                    .arg("NODE")
+                    .arg(target_node_id.clone());
+                let result: RedisResult<Value> =
+                    conn.route_command(&setslot_cmd, target_route.clone()).await;
+                match result {
+                    Ok(_) => {}
+                    Err(err) => {
+                        println!(
+                            "Failed to set slot {} to target NODE with error {}",
+                            slot, err
+                        );
+                    }
+                };
+                self.wait_for_connection_is_ready(&from_route)
+                    .await
+                    .unwrap();
+                self.wait_for_connection_is_ready(&target_route)
+                    .await
+                    .unwrap();
+                self.wait_for_cluster_up();
+            }
+        }
+    }
+
+    // Return the slots distribution of the cluster as a vector of tuples
+    // where the first element is the node id, seconed is host, third is port and the last element is a vector of slots ranges
+    pub fn get_slots_ranges_distribution(
+        &self,
+        cluster_nodes: &str,
+    ) -> Vec<(String, String, String, Vec<Vec<u16>>)> {
+        let nodes_string: Vec<String> = cluster_nodes
+            .split('\n')
+            .map(|s| s.to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        let mut nodes: Vec<Vec<String>> = vec![];
+        for node in nodes_string {
+            let node_vec: Vec<String> = node.split(' ').map(|s| s.to_string()).collect();
+            if node_vec.last().unwrap() == "connected" || node_vec.last().unwrap() == "disconnected"
+            {
+                continue;
+            } else {
+                nodes.push(node_vec);
+            }
+        }
+        let mut slot_distribution = vec![];
+        for node in &nodes {
+            let mut slots_ranges: Vec<Vec<u16>> = vec![];
+            let mut slots_ranges_vec: Vec<u16> = vec![];
+            let node_id = node[0].clone();
+            let host_and_port: Vec<String> = node[1].split(':').map(|s| s.to_string()).collect();
+            let host = host_and_port[0].clone();
+            let port = host_and_port[1].split('@').next().unwrap().to_string();
+            let slots = node[8..].to_vec();
+            for slot in slots {
+                if slot.contains("->") || slot.contains("<-") {
+                    continue;
+                }
+                if slot.contains('-') {
+                    let range: Vec<u16> =
+                        slot.split('-').map(|s| s.parse::<u16>().unwrap()).collect();
+                    slots_ranges_vec.push(range[0]);
+                    slots_ranges_vec.push(range[1]);
+                    slots_ranges.push(slots_ranges_vec.clone());
+                    slots_ranges_vec.clear();
+                } else {
+                    let slot: u16 = slot.parse::<u16>().unwrap();
+                    slots_ranges_vec.push(slot);
+                    slots_ranges_vec.push(slot);
+                    slots_ranges.push(slots_ranges_vec.clone());
+                    slots_ranges_vec.clear();
+                }
+            }
+            let parsed_node: (String, String, String, Vec<Vec<u16>>) =
+                (node_id, host, port, slots_ranges);
+            slot_distribution.push(parsed_node);
+        }
+        slot_distribution
+    }
+
+    pub async fn get_masters(&self, cluster_nodes: &str) -> Vec<Vec<String>> {
+        let mut masters = vec![];
+        for line in cluster_nodes.lines() {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() < 3 {
+                continue;
+            }
+            if parts[2] == "master" || parts[2] == "myself,master" {
+                let id = parts[0];
+                let host_and_port = parts[1].split(':');
+                let host = host_and_port.clone().next().unwrap();
+                let port = host_and_port
+                    .clone()
+                    .last()
+                    .unwrap()
+                    .split('@')
+                    .next()
+                    .unwrap();
+                masters.push(vec![id.to_string(), host.to_string(), port.to_string()]);
+            }
+        }
+        masters
+    }
+
+    pub async fn get_replicas(&self, cluster_nodes: &str) -> Vec<Vec<String>> {
+        let mut replicas = vec![];
+        for line in cluster_nodes.lines() {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() < 3 {
+                continue;
+            }
+            if parts[2] == "slave" || parts[2] == "myself,slave" {
+                let id = parts[0];
+                let host_and_port = parts[1].split(':');
+                let host = host_and_port.clone().next().unwrap();
+                let port = host_and_port
+                    .clone()
+                    .last()
+                    .unwrap()
+                    .split('@')
+                    .next()
+                    .unwrap();
+                replicas.push(vec![id.to_string(), host.to_string(), port.to_string()]);
+            }
+        }
+        replicas
+    }
+
+    pub async fn get_cluster_nodes(&self) -> String {
+        let mut conn = self.async_connection().await;
+        let mut cmd = redis::cmd("CLUSTER");
+        cmd.arg("NODES");
+        let res: RedisResult<Value> = conn
+            .route_command(&cmd, RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random))
+            .await;
+        let res: String = from_redis_value(&res.unwrap()).unwrap();
+        res
+    }
+
+    pub async fn wait_for_fail_to_finish(&self, route: &RoutingInfo) -> RedisResult<()> {
+        for _ in 0..500 {
+            let mut conn = self.async_connection().await;
+            let cmd = redis::cmd("PING");
+            let res: RedisResult<Value> = conn.route_command(&cmd, route.clone()).await;
+            if res.is_err() {
+                return Ok(());
+            }
+            sleep(Duration::from_millis(50));
+        }
+        Err(redis::RedisError::from((
+            redis::ErrorKind::IoError,
+            "Failed to get connection",
+        )))
+    }
+
+    pub async fn wait_for_connection_is_ready(&self, route: &RoutingInfo) -> RedisResult<()> {
+        let mut i = 1;
+        while i < 1000 {
+            let mut conn = self.async_connection().await;
+            let cmd = redis::cmd("PING");
+            let res: RedisResult<Value> = conn.route_command(&cmd, route.clone()).await;
+            if res.is_ok() {
+                return Ok(());
+            }
+            sleep(Duration::from_millis(i * 10));
+            i += 10;
+        }
+        Err(redis::RedisError::from((
+            redis::ErrorKind::IoError,
+            "Failed to get connection",
+        )))
     }
 }

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -143,8 +143,8 @@ pub enum Module {
 
 pub struct RedisServer {
     pub process: process::Child,
-    tempdir: tempfile::TempDir,
-    addr: redis::ConnectionAddr,
+    pub(crate) tempdir: tempfile::TempDir,
+    pub(crate) addr: redis::ConnectionAddr,
     pub(crate) tls_paths: Option<TlsFilePaths>,
 }
 

--- a/redis/tests/test_cluster_scan.rs
+++ b/redis/tests/test_cluster_scan.rs
@@ -38,7 +38,7 @@ mod test_cluster_scan_async {
                 .await;
         }
         let mut shutdown_cmd = cmd("SHUTDOWN");
-        shutdown_cmd.arg("NOSAVE").arg("NOW").arg("FORCE");
+        shutdown_cmd.arg("NOSAVE");
         let _: RedisResult<Value> = cluster_conn
             .route_command(&shutdown_cmd, random_node_route_info.clone())
             .await;
@@ -314,7 +314,7 @@ mod test_cluster_scan_async {
                 }
                 for master in masters.iter() {
                     let mut shut_cmd = cmd("SHUTDOWN");
-                    shut_cmd.arg("NOSAVE").arg("NOW").arg("FORCE");
+                    shut_cmd.arg("NOSAVE");
                     let _ = connection
                         .route_command(
                             &shut_cmd,
@@ -437,7 +437,7 @@ mod test_cluster_scan_async {
             if count == 5 {
                 for replica in replicas.iter() {
                     let mut shut_cmd = cmd("SHUTDOWN");
-                    shut_cmd.arg("NOSAVE").arg("NOW").arg("FORCE");
+                    shut_cmd.arg("NOSAVE");
                     let ready: RedisResult<Value> = connection
                         .route_command(
                             &shut_cmd,

--- a/redis/tests/test_cluster_scan.rs
+++ b/redis/tests/test_cluster_scan.rs
@@ -1,0 +1,768 @@
+#![cfg(feature = "cluster-async")]
+mod support;
+
+#[cfg(test)]
+mod test_cluster_scan_async {
+    use crate::support::*;
+    use rand::Rng;
+    use redis::cluster_routing::{RoutingInfo, SingleNodeRoutingInfo};
+    use redis::{cmd, from_redis_value, ObjectType, RedisResult, ScanStateCursor, Value};
+
+    async fn kill_one_node(
+        cluster: &TestClusterContext,
+        slot_distribution: Vec<(String, String, String, Vec<Vec<u16>>)>,
+    ) -> RoutingInfo {
+        let mut cluster_conn = cluster.async_connection().await;
+        let distribution_clone = slot_distribution.clone();
+        let index_of_random_node = rand::thread_rng().gen_range(0..slot_distribution.len());
+        let random_node = distribution_clone.get(index_of_random_node).unwrap();
+        let random_node_route_info = RoutingInfo::SingleNode(SingleNodeRoutingInfo::ByAddress {
+            host: random_node.1.clone(),
+            port: random_node.2.parse::<u16>().unwrap(),
+        });
+        let random_node_id = &random_node.0;
+        // Create connections to all nodes
+        for node in &distribution_clone {
+            if random_node_id == &node.0 {
+                continue;
+            }
+            let node_route = RoutingInfo::SingleNode(SingleNodeRoutingInfo::ByAddress {
+                host: node.1.clone(),
+                port: node.2.parse::<u16>().unwrap(),
+            });
+
+            let mut forget_cmd = cmd("CLUSTER");
+            forget_cmd.arg("FORGET").arg(random_node_id);
+            let _: RedisResult<Value> = cluster_conn
+                .route_command(&forget_cmd, node_route.clone())
+                .await;
+        }
+        let mut shutdown_cmd = cmd("SHUTDOWN");
+        shutdown_cmd.arg("NOSAVE").arg("NOW").arg("FORCE");
+        let _: RedisResult<Value> = cluster_conn
+            .route_command(&shutdown_cmd, random_node_route_info.clone())
+            .await;
+        random_node_route_info
+    }
+
+    #[tokio::test]
+    async fn test_async_cluster_scan() {
+        let cluster = TestClusterContext::new(3, 0);
+        let mut connection = cluster.async_connection().await;
+
+        // Set some keys
+        for i in 0..10 {
+            let key = format!("key{}", i);
+            let _: Result<(), redis::RedisError> = redis::cmd("SET")
+                .arg(&key)
+                .arg("value")
+                .query_async(&mut connection)
+                .await;
+        }
+
+        // Scan the keys
+        let mut scan_state_cursor = ScanStateCursor::new();
+        let mut keys: Vec<String> = vec![];
+        loop {
+            let (next_cursor, scan_keys): (ScanStateCursor, Vec<Value>) = connection
+                .cluster_scan(scan_state_cursor, None, None, None)
+                .await
+                .unwrap();
+            scan_state_cursor = next_cursor;
+            let mut scan_keys = scan_keys
+                .into_iter()
+                .map(|v| from_redis_value(&v).unwrap())
+                .collect::<Vec<String>>(); // Change the type of `keys` to `Vec<String>`
+            keys.append(&mut scan_keys);
+            if scan_state_cursor.is_none() {
+                break;
+            }
+        }
+        // Check if all keys were scanned
+        keys.sort();
+        keys.dedup();
+        for (i, key) in keys.iter().enumerate() {
+            assert_eq!(key.to_owned(), format!("key{}", i));
+        }
+    }
+
+    #[tokio::test] // test cluster scan with slot migration in the middle
+    async fn test_async_cluster_scan_with_migration() {
+        let cluster = TestClusterContext::new(3, 0);
+
+        let mut connection = cluster.async_connection().await;
+        // Set some keys
+        let mut expected_keys: Vec<String> = Vec::new();
+
+        for i in 0..1000 {
+            let key = format!("key{}", i);
+            let _: Result<(), redis::RedisError> = redis::cmd("SET")
+                .arg(&key)
+                .arg("value")
+                .query_async(&mut connection)
+                .await;
+            expected_keys.push(key);
+        }
+
+        // Scan the keys
+        let mut scan_state_cursor = ScanStateCursor::new();
+        let mut keys: Vec<String> = Vec::new();
+        let mut count = 0;
+        loop {
+            count += 1;
+            let (next_cursor, scan_keys): (ScanStateCursor, Vec<Value>) = connection
+                .cluster_scan(scan_state_cursor, None, None, None)
+                .await
+                .unwrap();
+            scan_state_cursor = next_cursor;
+            let scan_keys = scan_keys
+                .into_iter()
+                .map(|v| from_redis_value(&v).unwrap())
+                .collect::<Vec<String>>();
+            keys.extend(scan_keys);
+            if scan_state_cursor.is_none() {
+                break;
+            }
+            if count == 5 {
+                let mut cluster_nodes = cluster.get_cluster_nodes().await;
+                let slot_distribution = cluster.get_slots_ranges_distribution(&cluster_nodes);
+                cluster
+                    .migrate_slots_from_node_to_another(slot_distribution.clone())
+                    .await;
+                for node in &slot_distribution {
+                    let ready = cluster
+                        .wait_for_connection_is_ready(&RoutingInfo::SingleNode(
+                            SingleNodeRoutingInfo::ByAddress {
+                                host: node.1.clone(),
+                                port: node.2.parse::<u16>().unwrap(),
+                            },
+                        ))
+                        .await;
+                    match ready {
+                        Ok(_) => {}
+                        Err(e) => {
+                            println!("error: {:?}", e);
+                            break;
+                        }
+                    }
+                }
+
+                cluster_nodes = cluster.get_cluster_nodes().await;
+                // Compare slot distribution before and after migration
+                let new_slot_distribution = cluster.get_slots_ranges_distribution(&cluster_nodes);
+                assert_ne!(slot_distribution, new_slot_distribution);
+            }
+        }
+        keys.sort();
+        keys.dedup();
+        expected_keys.sort();
+        expected_keys.dedup();
+        // check if all keys were scanned
+        assert_eq!(keys, expected_keys);
+    }
+
+    #[tokio::test] // test cluster scan with node fail in the middle
+    async fn test_async_cluster_scan_with_fail() {
+        let cluster = TestClusterContext::new(3, 0);
+        let mut connection = cluster.async_connection().await;
+        // Set some keys
+        for i in 0..1000 {
+            let key = format!("key{}", i);
+            let _: Result<(), redis::RedisError> = redis::cmd("SET")
+                .arg(&key)
+                .arg("value")
+                .query_async(&mut connection)
+                .await;
+        }
+
+        // Scan the keys
+        let mut scan_state_cursor = ScanStateCursor::new();
+        let mut keys: Vec<String> = Vec::new();
+        let mut count = 0;
+        let mut result: RedisResult<Value> = Ok(Value::Nil);
+        loop {
+            count += 1;
+            let scan_response: RedisResult<(ScanStateCursor, Vec<Value>)> = connection
+                .cluster_scan(scan_state_cursor, None, None, None)
+                .await;
+            let (next_cursor, scan_keys) = match scan_response {
+                Ok((cursor, keys)) => (cursor, keys),
+                Err(e) => {
+                    result = Err(e);
+                    break;
+                }
+            };
+            scan_state_cursor = next_cursor;
+            keys.extend(scan_keys.into_iter().map(|v| from_redis_value(&v).unwrap()));
+            if scan_state_cursor.is_none() {
+                break;
+            }
+            if count == 5 {
+                let cluster_nodes = cluster.get_cluster_nodes().await;
+                let slot_distribution = cluster.get_slots_ranges_distribution(&cluster_nodes);
+                // simulate node failure
+                let killed_node_routing = kill_one_node(&cluster, slot_distribution.clone()).await;
+                let ready = cluster.wait_for_fail_to_finish(&killed_node_routing).await;
+                match ready {
+                    Ok(_) => {}
+                    Err(e) => {
+                        println!("error: {:?}", e);
+                        break;
+                    }
+                }
+                let cluster_nodes = cluster.get_cluster_nodes().await;
+                let new_slot_distribution = cluster.get_slots_ranges_distribution(&cluster_nodes);
+                assert_ne!(slot_distribution, new_slot_distribution);
+            }
+        }
+
+        // We expect an error of finding address covering slot or not all slots are covered
+        // Both errors message contains "please check the cluster configuration"
+        let res = result
+            .unwrap_err()
+            .to_string()
+            .contains("please check the cluster configuration");
+        assert!(res);
+    }
+
+    #[tokio::test] // Test cluster scan with killing all masters during scan
+    async fn test_async_cluster_scan_with_all_masters_down() {
+        let cluster = TestClusterContext::new(6, 1);
+
+        let mut connection = cluster.async_connection().await;
+
+        let mut expected_keys: Vec<String> = Vec::new();
+
+        cluster.wait_for_cluster_up();
+
+        let mut cluster_nodes = cluster.get_cluster_nodes().await;
+
+        let slot_distribution = cluster.get_slots_ranges_distribution(&cluster_nodes);
+        let masters = cluster.get_masters(&cluster_nodes).await;
+        let replicas = cluster.get_replicas(&cluster_nodes).await;
+
+        for i in 0..1000 {
+            let key = format!("key{}", i);
+            let _: Result<(), redis::RedisError> = redis::cmd("SET")
+                .arg(&key)
+                .arg("value")
+                .query_async(&mut connection)
+                .await;
+            expected_keys.push(key);
+        }
+        // Scan the keys
+        let mut scan_state_cursor = ScanStateCursor::new();
+        let mut keys: Vec<String> = Vec::new();
+        let mut count = 0;
+        loop {
+            count += 1;
+            let scan_response: RedisResult<(ScanStateCursor, Vec<Value>)> = connection
+                .cluster_scan(scan_state_cursor, None, None, None)
+                .await;
+            if scan_response.is_err() {
+                println!("error: {:?}", scan_response);
+            }
+            let (next_cursor, scan_keys) = scan_response.unwrap();
+            scan_state_cursor = next_cursor;
+            keys.extend(scan_keys.into_iter().map(|v| from_redis_value(&v).unwrap()));
+            if scan_state_cursor.is_none() {
+                break;
+            }
+            if count == 5 {
+                for replica in replicas.iter() {
+                    let mut failover_cmd = cmd("CLUSTER");
+                    let _: RedisResult<Value> = connection
+                        .route_command(
+                            failover_cmd.arg("FAILOVER").arg("TAKEOVER"),
+                            RoutingInfo::SingleNode(SingleNodeRoutingInfo::ByAddress {
+                                host: replica[1].clone(),
+                                port: replica[2].parse::<u16>().unwrap(),
+                            }),
+                        )
+                        .await;
+                    let ready = cluster
+                        .wait_for_connection_is_ready(&RoutingInfo::SingleNode(
+                            SingleNodeRoutingInfo::ByAddress {
+                                host: replica[1].clone(),
+                                port: replica[2].parse::<u16>().unwrap(),
+                            },
+                        ))
+                        .await;
+                    match ready {
+                        Ok(_) => {}
+                        Err(e) => {
+                            println!("error: {:?}", e);
+                            break;
+                        }
+                    }
+                }
+
+                for master in masters.iter() {
+                    for replica in replicas.clone() {
+                        let mut forget_cmd = cmd("CLUSTER");
+                        forget_cmd.arg("FORGET").arg(master[0].clone());
+                        let _: RedisResult<Value> = connection
+                            .route_command(
+                                &forget_cmd,
+                                RoutingInfo::SingleNode(SingleNodeRoutingInfo::ByAddress {
+                                    host: replica[1].clone(),
+                                    port: replica[2].parse::<u16>().unwrap(),
+                                }),
+                            )
+                            .await;
+                    }
+                }
+                for master in masters.iter() {
+                    let mut shut_cmd = cmd("SHUTDOWN");
+                    shut_cmd.arg("NOSAVE").arg("NOW").arg("FORCE");
+                    let _ = connection
+                        .route_command(
+                            &shut_cmd,
+                            RoutingInfo::SingleNode(SingleNodeRoutingInfo::ByAddress {
+                                host: master[1].clone(),
+                                port: master[2].parse::<u16>().unwrap(),
+                            }),
+                        )
+                        .await;
+                    let ready = cluster
+                        .wait_for_fail_to_finish(&RoutingInfo::SingleNode(
+                            SingleNodeRoutingInfo::ByAddress {
+                                host: master[1].clone(),
+                                port: master[2].parse::<u16>().unwrap(),
+                            },
+                        ))
+                        .await;
+                    match ready {
+                        Ok(_) => {}
+                        Err(e) => {
+                            println!("error: {:?}", e);
+                            break;
+                        }
+                    }
+                }
+                for replica in replicas.iter() {
+                    let ready = cluster
+                        .wait_for_connection_is_ready(&RoutingInfo::SingleNode(
+                            SingleNodeRoutingInfo::ByAddress {
+                                host: replica[1].clone(),
+                                port: replica[2].parse::<u16>().unwrap(),
+                            },
+                        ))
+                        .await;
+                    match ready {
+                        Ok(_) => {}
+                        Err(e) => {
+                            println!("error: {:?}", e);
+                            break;
+                        }
+                    }
+                }
+                cluster_nodes = cluster.get_cluster_nodes().await;
+                let new_slot_distribution = cluster.get_slots_ranges_distribution(&cluster_nodes);
+                assert_ne!(slot_distribution, new_slot_distribution);
+            }
+        }
+        keys.sort();
+        keys.dedup();
+        expected_keys.sort();
+        expected_keys.dedup();
+        // check if all keys were scanned
+        assert_eq!(keys, expected_keys);
+    }
+
+    #[tokio::test]
+    // Test cluster scan with killing all replicas during scan
+    async fn test_async_cluster_scan_with_all_replicas_down() {
+        let cluster = TestClusterContext::new(6, 1);
+
+        let mut connection = cluster.async_connection().await;
+
+        let mut expected_keys: Vec<String> = Vec::new();
+
+        for server in cluster.cluster.servers.iter() {
+            let addres = server.addr.clone().to_string();
+            let host_and_port = addres.split(':');
+            let host = host_and_port.clone().next().unwrap().to_string();
+            let port = host_and_port
+                .clone()
+                .last()
+                .unwrap()
+                .parse::<u16>()
+                .unwrap();
+            let ready = cluster
+                .wait_for_connection_is_ready(&RoutingInfo::SingleNode(
+                    SingleNodeRoutingInfo::ByAddress { host, port },
+                ))
+                .await;
+            match ready {
+                Ok(_) => {}
+                Err(e) => {
+                    println!("error: {:?}", e);
+                    break;
+                }
+            }
+        }
+
+        let cluster_nodes = cluster.get_cluster_nodes().await;
+
+        let replicas = cluster.get_replicas(&cluster_nodes).await;
+
+        for i in 0..1000 {
+            let key = format!("key{}", i);
+            let _: Result<(), redis::RedisError> = redis::cmd("SET")
+                .arg(&key)
+                .arg("value")
+                .query_async(&mut connection)
+                .await;
+            expected_keys.push(key);
+        }
+        // Scan the keys
+        let mut scan_state_cursor = ScanStateCursor::new();
+        let mut keys: Vec<String> = Vec::new();
+        let mut count = 0;
+        loop {
+            count += 1;
+            let scan_response: RedisResult<(ScanStateCursor, Vec<Value>)> = connection
+                .cluster_scan(scan_state_cursor, None, None, None)
+                .await;
+            if scan_response.is_err() {
+                println!("error: {:?}", scan_response);
+            }
+            let (next_cursor, scan_keys) = scan_response.unwrap();
+            scan_state_cursor = next_cursor;
+            keys.extend(scan_keys.into_iter().map(|v| from_redis_value(&v).unwrap()));
+            if scan_state_cursor.is_none() {
+                break;
+            }
+            if count == 5 {
+                for replica in replicas.iter() {
+                    let mut shut_cmd = cmd("SHUTDOWN");
+                    shut_cmd.arg("NOSAVE").arg("NOW").arg("FORCE");
+                    let ready: RedisResult<Value> = connection
+                        .route_command(
+                            &shut_cmd,
+                            RoutingInfo::SingleNode(SingleNodeRoutingInfo::ByAddress {
+                                host: replica[1].clone(),
+                                port: replica[2].parse::<u16>().unwrap(),
+                            }),
+                        )
+                        .await;
+                    match ready {
+                        Ok(_) => {}
+                        Err(e) => {
+                            println!("error: {:?}", e);
+                            break;
+                        }
+                    }
+                }
+                let new_cluster_nodes = cluster.get_cluster_nodes().await;
+                assert_ne!(cluster_nodes, new_cluster_nodes);
+            }
+        }
+        keys.sort();
+        keys.dedup();
+        expected_keys.sort();
+        expected_keys.dedup();
+        // check if all keys were scanned
+        assert_eq!(keys, expected_keys);
+    }
+    #[tokio::test]
+    // Test cluster scan with setting keys for each iteration
+    async fn test_async_cluster_scan_set_in_the_middle() {
+        let cluster = TestClusterContext::new(3, 0);
+        let mut connection = cluster.async_connection().await;
+        let mut expected_keys: Vec<String> = Vec::new();
+        let mut i = 0;
+        // Set some keys
+        loop {
+            let key = format!("key{}", i);
+            let _: Result<(), redis::RedisError> = redis::cmd("SET")
+                .arg(&key)
+                .arg("value")
+                .query_async(&mut connection)
+                .await;
+            expected_keys.push(key);
+            i += 1;
+            if i == 1000 {
+                break;
+            }
+        }
+        // Scan the keys
+        let mut scan_state_cursor = ScanStateCursor::new();
+        let mut keys: Vec<String> = vec![];
+        loop {
+            let (next_cursor, scan_keys): (ScanStateCursor, Vec<Value>) = connection
+                .cluster_scan(scan_state_cursor, None, None, None)
+                .await
+                .unwrap();
+            scan_state_cursor = next_cursor;
+            let mut scan_keys = scan_keys
+                .into_iter()
+                .map(|v| from_redis_value(&v).unwrap())
+                .collect::<Vec<String>>(); // Change the type of `keys` to `Vec<String>`
+            keys.append(&mut scan_keys);
+            if scan_state_cursor.is_none() {
+                break;
+            }
+            let key = format!("key{}", i);
+            i += 1;
+            let res: Result<(), redis::RedisError> = redis::cmd("SET")
+                .arg(&key)
+                .arg("value")
+                .query_async(&mut connection)
+                .await;
+            assert!(res.is_ok());
+        }
+        // Check if all keys were scanned
+        keys.sort();
+        keys.dedup();
+        expected_keys.sort();
+        expected_keys.dedup();
+        // check if all keys were scanned
+        for key in expected_keys.iter() {
+            assert!(keys.contains(key));
+        }
+        assert!(keys.len() >= expected_keys.len());
+    }
+
+    #[tokio::test]
+    // Test cluster scan with deleting keys for each iteration
+    async fn test_async_cluster_scan_dell_in_the_middle() {
+        let cluster = TestClusterContext::new(3, 0);
+
+        let mut connection = cluster.async_connection().await;
+        let mut expected_keys: Vec<String> = Vec::new();
+        let mut i = 0;
+        // Set some keys
+        loop {
+            let key = format!("key{}", i);
+            let _: Result<(), redis::RedisError> = redis::cmd("SET")
+                .arg(&key)
+                .arg("value")
+                .query_async(&mut connection)
+                .await;
+            expected_keys.push(key);
+            i += 1;
+            if i == 1000 {
+                break;
+            }
+        }
+        // Scan the keys
+        let mut scan_state_cursor = ScanStateCursor::new();
+        let mut keys: Vec<String> = vec![];
+        loop {
+            let (next_cursor, scan_keys): (ScanStateCursor, Vec<Value>) = connection
+                .cluster_scan(scan_state_cursor, None, None, None)
+                .await
+                .unwrap();
+            scan_state_cursor = next_cursor;
+            let mut scan_keys = scan_keys
+                .into_iter()
+                .map(|v| from_redis_value(&v).unwrap())
+                .collect::<Vec<String>>(); // Change the type of `keys` to `Vec<String>`
+            keys.append(&mut scan_keys);
+            if scan_state_cursor.is_none() {
+                break;
+            }
+            i -= 1;
+            let key = format!("key{}", i);
+
+            let res: Result<(), redis::RedisError> = redis::cmd("del")
+                .arg(&key)
+                .arg("value")
+                .query_async(&mut connection)
+                .await;
+            assert!(res.is_ok());
+            expected_keys.remove(i as usize);
+        }
+        // Check if all keys were scanned
+        keys.sort();
+        keys.dedup();
+        expected_keys.sort();
+        expected_keys.dedup();
+        // check if all keys were scanned
+        for key in expected_keys.iter() {
+            assert!(keys.contains(key));
+        }
+        assert!(keys.len() >= expected_keys.len());
+    }
+
+    #[tokio::test]
+    // Testing cluster scan with Pattern option
+    async fn test_async_cluster_scan_with_pattern() {
+        let cluster = TestClusterContext::new(3, 0);
+        let mut connection = cluster.async_connection().await;
+        let mut expected_keys: Vec<String> = Vec::new();
+        let mut i = 0;
+        // Set some keys
+        loop {
+            let key = format!("key:pattern:{}", i);
+            let _: Result<(), redis::RedisError> = redis::cmd("SET")
+                .arg(&key)
+                .arg("value")
+                .query_async(&mut connection)
+                .await;
+            expected_keys.push(key);
+            let non_relevant_key = format!("key{}", i);
+            let _: Result<(), redis::RedisError> = redis::cmd("SET")
+                .arg(&non_relevant_key)
+                .arg("value")
+                .query_async(&mut connection)
+                .await;
+            i += 1;
+            if i == 500 {
+                break;
+            }
+        }
+
+        // Scan the keys
+        let mut scan_state_cursor = ScanStateCursor::new();
+        let mut keys: Vec<String> = vec![];
+        loop {
+            let (next_cursor, scan_keys): (ScanStateCursor, Vec<Value>) = connection
+                .cluster_scan(scan_state_cursor, Some("key:pattern:*"), None, None)
+                .await
+                .unwrap();
+            scan_state_cursor = next_cursor;
+            let mut scan_keys = scan_keys
+                .into_iter()
+                .map(|v| from_redis_value(&v).unwrap())
+                .collect::<Vec<String>>(); // Change the type of `keys` to `Vec<String>`
+            keys.append(&mut scan_keys);
+            if scan_state_cursor.is_none() {
+                break;
+            }
+        }
+        // Check if all keys were scanned
+        keys.sort();
+        keys.dedup();
+        expected_keys.sort();
+        expected_keys.dedup();
+        // check if all keys were scanned
+        for key in expected_keys.iter() {
+            assert!(keys.contains(key));
+        }
+        assert!(keys.len() == expected_keys.len());
+    }
+
+    #[tokio::test]
+    // Testing cluster scan with TYPE option
+    async fn test_async_cluster_scan_with_type() {
+        let cluster = TestClusterContext::new(3, 0);
+        let mut connection = cluster.async_connection().await;
+        let mut expected_keys: Vec<String> = Vec::new();
+        let mut i = 0;
+        // Set some keys
+        loop {
+            let key = format!("key{}", i);
+            let _: Result<(), redis::RedisError> = redis::cmd("SADD")
+                .arg(&key)
+                .arg("value")
+                .query_async(&mut connection)
+                .await;
+            expected_keys.push(key);
+            let key = format!("key-that-is-not-set{}", i);
+            let _: Result<(), redis::RedisError> = redis::cmd("SET")
+                .arg(&key)
+                .arg("value")
+                .query_async(&mut connection)
+                .await;
+            i += 1;
+            if i == 500 {
+                break;
+            }
+        }
+
+        // Scan the keys
+        let mut scan_state_cursor = ScanStateCursor::new();
+        let mut keys: Vec<String> = vec![];
+        loop {
+            let (next_cursor, scan_keys): (ScanStateCursor, Vec<Value>) = connection
+                .cluster_scan(scan_state_cursor, None, None, Some(ObjectType::SET))
+                .await
+                .unwrap();
+            scan_state_cursor = next_cursor;
+            let mut scan_keys = scan_keys
+                .into_iter()
+                .map(|v| from_redis_value(&v).unwrap())
+                .collect::<Vec<String>>(); // Change the type of `keys` to `Vec<String>`
+            keys.append(&mut scan_keys);
+            if scan_state_cursor.is_none() {
+                break;
+            }
+        }
+        // Check if all keys were scanned
+        keys.sort();
+        keys.dedup();
+        expected_keys.sort();
+        expected_keys.dedup();
+        // check if all keys were scanned
+        for key in expected_keys.iter() {
+            assert!(keys.contains(key));
+        }
+        assert!(keys.len() == expected_keys.len());
+    }
+
+    #[tokio::test]
+    // Testing cluster scan with COUNT option
+    async fn test_async_cluster_scan_with_count() {
+        let cluster = TestClusterContext::new(3, 0);
+        let mut connection = cluster.async_connection().await;
+        let mut expected_keys: Vec<String> = Vec::new();
+        let mut i = 0;
+        // Set some keys
+        loop {
+            let key = format!("key{}", i);
+            let _: Result<(), redis::RedisError> = redis::cmd("SET")
+                .arg(&key)
+                .arg("value")
+                .query_async(&mut connection)
+                .await;
+            expected_keys.push(key);
+            i += 1;
+            if i == 1000 {
+                break;
+            }
+        }
+
+        // Scan the keys
+        let mut scan_state_cursor = ScanStateCursor::new();
+        let mut keys: Vec<String> = vec![];
+        let mut comparing_times = 0;
+        loop {
+            let (next_cursor, scan_keys): (ScanStateCursor, Vec<Value>) = connection
+                .cluster_scan(scan_state_cursor.clone(), None, Some(100), None)
+                .await
+                .unwrap();
+            let (_, scan_without_count_keys): (ScanStateCursor, Vec<Value>) = connection
+                .cluster_scan(scan_state_cursor, None, Some(100), None)
+                .await
+                .unwrap();
+            if !scan_keys.is_empty() && !scan_without_count_keys.is_empty() {
+                assert!(scan_keys.len() >= scan_without_count_keys.len());
+
+                comparing_times += 1;
+            }
+            scan_state_cursor = next_cursor;
+            let mut scan_keys = scan_keys
+                .into_iter()
+                .map(|v| from_redis_value(&v).unwrap())
+                .collect::<Vec<String>>(); // Change the type of `keys` to `Vec<String>`
+            keys.append(&mut scan_keys);
+            if scan_state_cursor.is_none() {
+                break;
+            }
+        }
+        assert!(comparing_times > 0);
+        // Check if all keys were scanned
+        keys.sort();
+        keys.dedup();
+        expected_keys.sort();
+        expected_keys.dedup();
+        // check if all keys were scanned
+        for key in expected_keys.iter() {
+            assert!(keys.contains(key));
+        }
+        assert!(keys.len() == expected_keys.len());
+    }
+}


### PR DESCRIPTION
This PR contains the implementation of scanning a Redis cluster.

### The logical idea:
Replacing the `cursor` the user use to interact with the SCAN process by a state cursor representing the state of the scan base on the internal logic implemented.
The general idea is behind the scene to scan node by node and track the progress and changes of the cluster topology affects the scan and adjust the scan accordingly, while still keep the promises of the scan operation, such as returning all keys were in the cluster from beginning to end or keep the operation "stateless", do it efficiently, and give the user the touch and feel of a standalone server.

#### The state struct include - 
1. `cursor` - The real cursor is used to scan the current node.
2. `scanned_slots_map` - a 16384 bits array, represent the progress of the scan, in which slots that been scanned are set to 1 while the other are set to 0.
4. `address_in_scan` - the address of the node that is under scan.
5. `node_epoch` - represent the epoch of the node that is currently under scan. `epoch` in general represent the amount of changes that a node had not including slots that has moved in to the node. This field is helping us when checking if the node slots changed during the scan to avoid a scenario in which slots moved in and out without leaving mark on the slots map.
 
#### The flow of then scan -
In each call the scan will check if its a new scan by checking if ScanState is None.
When the user like to initiate a new scan he will send an empty ref to ScanState, provided as `ScanStateCursor` which represent `Arc<Option<ScanState>>`.
If the cursor got is none, which mean its a new scan, the scan will call `initiate_scan` which create a new `ScanState` holding the address responsible for slot 0, get the node epoch and set a 0 cursor and an empty map as the `scanned_slots_map`.
For "not new" scans, the method will send a new scan command to the current address.
I the call fail we will try to refresh typology in order to find another node that is responsible for the current slots being scanned and retry the scan.
If no other address find or the slots are not covered, we will fail the scan and return an error.

If a scan call return 0 we know that we finished scanning a node -
We will check which slots are covered by the node and then check the epoch,
If the epoch changed, we can't determine which slots are actually scanned, so we'll need to update the scan state without marking any slot as scanned.
If the epoch hasn't changed we will mark all the slots covered by the node as scan in the scanned_slot_map, and will update the scan state accordingly by finding the address of the next slot that haven't being scanned, and its epoch.
if the scanned slots map is complete we finished the scan and we will return a none cursor, which is equivalents to 0 cursor in a classic scan. 

We always creating new ScanState instead of updating the old one - we do so in order to keep the scan operation "stateless", meaning - in any point, with the same DB and the same input, the result will be the same.
We do not hold any state internally. We give the user a smart ref, if he hold it, the state is exist, if he drop it the state is dropped, exactly as it is with the scan cursor while working with a stand-alone server.
The user is allowed to call to the same ref over and over, or start a new scan in any point, and our impl' will not affect it in any way.
The goal is to keep the touch and feel of a stand-alone server while working with a cluster, plus avoiding side affects the can be presented by internal implementation of a state.
 
Overall, this module provides a convenient and efficient way to perform key scanning in a Redis cluster,keeping the promises of a standalone scan.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
