### PR TITLE
Added hardcoded user TCP timeout

### DIFF
--- a/redis/src/aio/tokio.rs
+++ b/redis/src/aio/tokio.rs
@@ -5,6 +5,7 @@ use std::{
     io,
     pin::Pin,
     task::{self, Poll},
+    time::Duration,
 };
 #[cfg(unix)]
 use tokio::net::UnixStream as UnixStreamTokio;
@@ -48,6 +49,9 @@ async fn connect_tcp(addr: &SocketAddr) -> io::Result<TcpStreamTokio> {
         let std_socket = socket.into_std()?;
         let socket2: socket2::Socket = std_socket.into();
         socket2.set_tcp_keepalive(&KEEP_ALIVE)?;
+        // TODO: Replace this hardcoded timeout with a configurable timeout when https://github.com/redis-rs/redis-rs/issues/1147 is resolved
+        const DFEAULT_USER_TCP_TIMEOUT: Duration = Duration::from_secs(5);
+        socket2.set_tcp_user_timeout(Some(DFEAULT_USER_TCP_TIMEOUT))?;
         TcpStreamTokio::from_std(socket2.into())
     }
 


### PR DESCRIPTION
We've encountered situations where the server's host fails to respond with an ACK to a transmitted message, causing the connection to hang on send_recv. To resolve this issue, we've implemented the socket2 set_tcp_user_timeout function. 

Currently, this PR introduces a hardcoded timeout value of 5 seconds. However, in the future, when we have more resources, we plan to make it a configurable variable. You can find more information at https://github.com/redis-rs/redis-rs/issues/1147.