### PR TITLE
Fix TCP_USER_TIMEOUT compatibility with different OS and analyzer

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -42,7 +42,7 @@ futures-util = { version = "0.3.15", default-features = false, optional = true }
 pin-project-lite = { version = "0.2", optional = true }
 tokio-util = { version = "0.7", optional = true }
 tokio = { version = "1", features = ["rt", "net", "time", "sync"] }
-socket2 = { version = "0.5", default-features = false, optional = true }
+socket2 = { version = "0.5", features = ["all"], optional = true }
 fast-math = { version = "0.1.1", optional = true }
 dispose = { version = "0.5.0", optional = true }
 

--- a/redis/src/aio/tokio.rs
+++ b/redis/src/aio/tokio.rs
@@ -49,9 +49,13 @@ async fn connect_tcp(addr: &SocketAddr) -> io::Result<TcpStreamTokio> {
         let std_socket = socket.into_std()?;
         let socket2: socket2::Socket = std_socket.into();
         socket2.set_tcp_keepalive(&KEEP_ALIVE)?;
-        // TODO: Replace this hardcoded timeout with a configurable timeout when https://github.com/redis-rs/redis-rs/issues/1147 is resolved
-        const DFEAULT_USER_TCP_TIMEOUT: Duration = Duration::from_secs(5);
-        socket2.set_tcp_user_timeout(Some(DFEAULT_USER_TCP_TIMEOUT))?;
+        // TCP_USER_TIMEOUT configuration isn't supported across all operation systems
+        #[cfg(all(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))]
+        {
+            // TODO: Replace this hardcoded timeout with a configurable timeout when https://github.com/redis-rs/redis-rs/issues/1147 is resolved
+            const DFEAULT_USER_TCP_TIMEOUT: Duration = Duration::from_secs(5);
+            socket2.set_tcp_user_timeout(Some(DFEAULT_USER_TCP_TIMEOUT))?;
+        }
         TcpStreamTokio::from_std(socket2.into())
     }
 

--- a/redis/src/aio/tokio.rs
+++ b/redis/src/aio/tokio.rs
@@ -50,7 +50,7 @@ async fn connect_tcp(addr: &SocketAddr) -> io::Result<TcpStreamTokio> {
         let socket2: socket2::Socket = std_socket.into();
         socket2.set_tcp_keepalive(&KEEP_ALIVE)?;
         // TCP_USER_TIMEOUT configuration isn't supported across all operation systems
-        #[cfg(all(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))]
+        #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
         {
             // TODO: Replace this hardcoded timeout with a configurable timeout when https://github.com/redis-rs/redis-rs/issues/1147 is resolved
             const DFEAULT_USER_TCP_TIMEOUT: Duration = Duration::from_secs(5);


### PR DESCRIPTION
1. Adjusted socket2 features to address analyzer error. 
2. TCP User Timeout: Introduced target_os configuration, recognizing that this feature lacks support across all operating systems.
3. 
