### PR TITLE
Added UNWATCH to AllPrimaries routing

### DIFF
--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -383,7 +383,7 @@ fn base_routing(cmd: &[u8]) -> RouteBy {
         | b"RANDOMKEY"
         | b"WAITAOF" => RouteBy::AllPrimaries,
 
-        b"MGET" | b"DEL" | b"EXISTS" | b"UNLINK" | b"TOUCH" => RouteBy::MultiShardNoValues,
+        b"MGET" | b"DEL" | b"EXISTS" | b"UNLINK" | b"TOUCH" | b"WATCH" => RouteBy::MultiShardNoValues,
         b"MSET" => RouteBy::MultiShardWithValues,
 
         // TODO - special handling - b"SCAN"

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -383,7 +383,9 @@ fn base_routing(cmd: &[u8]) -> RouteBy {
         | b"RANDOMKEY"
         | b"WAITAOF" => RouteBy::AllPrimaries,
 
-        b"MGET" | b"DEL" | b"EXISTS" | b"UNLINK" | b"TOUCH" | b"WATCH" => RouteBy::MultiShardNoValues,
+        b"MGET" | b"DEL" | b"EXISTS" | b"UNLINK" | b"TOUCH" | b"WATCH" => {
+            RouteBy::MultiShardNoValues
+        }
         b"MSET" => RouteBy::MultiShardWithValues,
 
         // TODO - special handling - b"SCAN"

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -378,6 +378,7 @@ fn base_routing(cmd: &[u8]) -> RouteBy {
         | b"PING"
         | b"SCRIPT EXISTS"
         | b"SCRIPT KILL"
+        | b"UNWATCH"
         | b"WAIT"
         | b"RANDOMKEY"
         | b"WAITAOF" => RouteBy::AllPrimaries,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`WATCH` and `UNWATCH` works on cluster client only if `UNWATCH` was accidentally routed to the same node where key is located.

Running this test fails on the last assert as it mostly returns null because `UNWATCH` doesn't hit the right node.
```
String key = "a";
ClusterTransaction testTrans = new ClusterTransaction();
clusterClient.set(key, "init").get();
clusterClient.watch(new String[] {key}).get();
clusterClient.customCommand(new String[] {"unwatch"},
    SimpleSingleNodeRoute.RANDOM).get();
clusterClient.set(key, "racecondition").get();
testTrans.set(key, "doesthiswork");
assertArrayEquals(new String[] {OK}, clusterClient.exec(testTrans).get());
assertEquals("doesthiswork", clusterClient.get(key).get()); // Returns null 
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
