### PR TITLE
Async cluster: Changed OneSucceededNonEmpty to FirstSucceededNonEmptyOrAllEmpty

### DIFF
--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -605,18 +605,29 @@ where
                 Err(last_failure
                     .unwrap_or_else(|| (ErrorKind::IoError, "Couldn't find a connection").into()))
             }
-            Some(ResponsePolicy::OneSucceededNonEmpty) => {
+            Some(ResponsePolicy::FirstSucceededNonEmptyOrAllEmpty) => {
+                // Attempt to return the first result that isn't `Nil` or an error.
+                // If no such response is found and all servers returned `Nil`, it indicates that all shards are empty, so return `Nil`.
+                // If we received only errors, return the last received error.
+                // If we received a mix of errors and `Nil`s, we can't determine if all shards are empty,
+                // thus we return the last received error instead of `Nil`.
                 let mut last_failure = None;
-
+                let num_of_results = results.len();
+                let mut nil_counter = 0;
                 for result in results {
                     match result.map(|(_, res)| res) {
-                        Ok(Value::Nil) => continue,
+                        Ok(Value::Nil) => nil_counter += 1,
                         Ok(val) => return Ok(val),
                         Err(err) => last_failure = Some(err),
                     }
                 }
-                Err(last_failure
-                    .unwrap_or_else(|| (ErrorKind::IoError, "Couldn't find a connection").into()))
+                if nil_counter == num_of_results {
+                    Ok(Value::Nil)
+                } else {
+                    Err(last_failure.unwrap_or_else(|| {
+                        (ErrorKind::IoError, "Couldn't find a connection").into()
+                    }))
+                }
             }
             Some(ResponsePolicy::Aggregate(op)) => {
                 let results = results

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -58,6 +58,7 @@ use crate::{
     Cmd, ConnectionInfo, ErrorKind, IntoConnectionInfo, RedisError, RedisFuture, RedisResult,
     Value,
 };
+use futures::stream::{FuturesUnordered, StreamExt};
 use std::time::Duration;
 
 #[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
@@ -867,17 +868,34 @@ where
             .await
             .map(|(result, _)| result),
             Some(ResponsePolicy::OneSucceededNonEmpty) => {
-                future::select_ok(receivers.into_iter().map(|(_, receiver)| {
-                    Box::pin(async move {
-                        let result = convert_result(receiver.await)?;
-                        match result {
-                            Value::Nil => Err((ErrorKind::ResponseError, "no value found").into()),
-                            _ => Ok(result),
-                        }
-                    })
-                }))
-                .await
-                .map(|(result, _)| result)
+                // Try to get the first result that isn't nil or an error. If no such response is found,
+                // return nil if at least one of the servers returned nil; otherwise, return the last received error.
+                let mut futures = receivers
+                    .into_iter()
+                    .map(get_receiver)
+                    .collect::<FuturesUnordered<_>>();
+
+                let mut nil_found = false;
+                let mut last_err = None;
+                while let Some(result) = futures.next().await {
+                    match result {
+                        Ok(Value::Nil) => nil_found = true,
+                        Ok(val) => return Ok(val),
+                        Err(e) => last_err = Some(e),
+                    }
+                }
+
+                if nil_found {
+                    Ok(Value::Nil)
+                } else {
+                    Err(last_err.unwrap_or_else(|| {
+                        (
+                            ErrorKind::ClusterConnectionNotFound,
+                            "Couldn't find any connection",
+                        )
+                            .into()
+                    }))
+                }
             }
             Some(ResponsePolicy::Aggregate(op)) => {
                 future::try_join_all(receivers.into_iter().map(get_receiver))

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -867,7 +867,7 @@ where
             )
             .await
             .map(|(result, _)| result),
-            Some(ResponsePolicy::OneSucceededNonEmpty) => {
+            Some(ResponsePolicy::FirstSucceededNonEmptyOrAllEmpty) => {
                 // Attempt to return the first result that isn't `Nil` or an error.
                 // If no such response is found and all servers returned `Nil`, it indicates that all shards are empty, so return `Nil`.
                 // If we received only errors, return the last received error.

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -36,8 +36,8 @@ pub enum AggregateOp {
 pub enum ResponsePolicy {
     /// Wait for one request to succeed and return its results. Return error if all requests fail.
     OneSucceeded,
-    /// Wait for one request to succeed with a non-empty value. Return error if all requests fail or return `Nil`.
-    OneSucceededNonEmpty,
+    /// Returns the first succeeded non-empty result; if all results are empty, returns `Nil`; otherwise, returns the last received error.
+    FirstSucceededNonEmptyOrAllEmpty,
     /// Waits for all requests to succeed, and the returns one of the successes. Returns the error on the first received error.
     AllSucceeded,
     /// Aggregate success results according to a logical bitwise operator. Return error on any failed request or on a response that doesn't conform to 0 or 1.
@@ -319,7 +319,7 @@ impl ResponsePolicy {
             b"FUNCTION KILL" | b"SCRIPT KILL" => Some(ResponsePolicy::OneSucceeded),
 
             // This isn't based on response_tips, but on the discussion here - https://github.com/redis/redis/issues/12410
-            b"RANDOMKEY" => Some(ResponsePolicy::OneSucceededNonEmpty),
+            b"RANDOMKEY" => Some(ResponsePolicy::FirstSucceededNonEmptyOrAllEmpty),
 
             b"LATENCY GRAPH" | b"LATENCY HISTOGRAM" | b"LATENCY HISTORY" | b"LATENCY DOCTOR"
             | b"LATENCY LATEST" => Some(ResponsePolicy::Special),

--- a/redis/tests/support/mock_cluster.rs
+++ b/redis/tests/support/mock_cluster.rs
@@ -264,22 +264,7 @@ pub fn respond_startup_with_replica(name: &str, cmd: &[u8]) -> Result<(), RedisR
 }
 
 pub fn respond_startup_two_nodes(name: &str, cmd: &[u8]) -> Result<(), RedisResult<Value>> {
-    respond_startup_with_replica_using_config(
-        name,
-        cmd,
-        Some(vec![
-            MockSlotRange {
-                primary_port: 6379,
-                replica_ports: vec![],
-                slot_range: (0..8191),
-            },
-            MockSlotRange {
-                primary_port: 6380,
-                replica_ports: vec![],
-                slot_range: (8192..16383),
-            },
-        ]),
-    )
+    respond_startup_with_config(name, cmd, None, false)
 }
 
 pub fn create_topology_from_config(name: &str, slots_config: Vec<MockSlotRange>) -> Value {
@@ -311,18 +296,43 @@ pub fn respond_startup_with_replica_using_config(
     cmd: &[u8],
     slots_config: Option<Vec<MockSlotRange>>,
 ) -> Result<(), RedisResult<Value>> {
-    let slots_config = slots_config.unwrap_or(vec![
-        MockSlotRange {
-            primary_port: 6379,
-            replica_ports: vec![6380],
-            slot_range: (0..8191),
-        },
-        MockSlotRange {
-            primary_port: 6381,
-            replica_ports: vec![6382],
-            slot_range: (8192..16383),
-        },
-    ]);
+    respond_startup_with_config(name, cmd, slots_config, true)
+}
+
+/// If the configuration isn't provided, a configuration with two primary nodes, with or without replicas, will be used.
+pub fn respond_startup_with_config(
+    name: &str,
+    cmd: &[u8],
+    slots_config: Option<Vec<MockSlotRange>>,
+    with_replicas: bool,
+) -> Result<(), RedisResult<Value>> {
+    let slots_config = slots_config.unwrap_or(if with_replicas {
+        vec![
+            MockSlotRange {
+                primary_port: 6379,
+                replica_ports: vec![6380],
+                slot_range: (0..8191),
+            },
+            MockSlotRange {
+                primary_port: 6381,
+                replica_ports: vec![6382],
+                slot_range: (8192..16383),
+            },
+        ]
+    } else {
+        vec![
+            MockSlotRange {
+                primary_port: 6379,
+                replica_ports: vec![],
+                slot_range: (0..8191),
+            },
+            MockSlotRange {
+                primary_port: 6380,
+                replica_ports: vec![],
+                slot_range: (8192..16383),
+            },
+        ]
+    });
     if contains_slice(cmd, b"PING") || contains_slice(cmd, b"SETNAME") {
         Err(Ok(Value::SimpleString("OK".into())))
     } else if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -1768,9 +1768,10 @@ mod cluster_async {
     }
 
     #[test]
-    fn test_async_cluster_one_succeeded_non_empty_return_value_ignoring_nil_and_err_responses() {
+    fn test_async_cluster_first_succeeded_non_empty_or_all_empty_return_value_ignoring_nil_and_err_resps(
+    ) {
         let name =
-            "test_async_cluster_fan_out_and_return_one_succeeded_ignoring_nil_and_err_responses";
+            "test_async_cluster_first_succeeded_non_empty_or_all_empty_return_value_ignoring_nil_and_err_resps";
         let cmd = cmd("RANDOMKEY");
         let MockEnv {
             runtime,
@@ -1786,9 +1787,9 @@ mod cluster_async {
                 let ports = vec![6379, 6380, 6381];
                 let slots_config_vec = generate_topology_view(&ports, 1000, true);
                 respond_startup_with_config(name, received_cmd, Some(slots_config_vec), false)?;
-                if port == 6381 {
+                if port == 6380 {
                     return Err(Ok(Value::BulkString("foo".as_bytes().to_vec())));
-                } else if port == 6380 {
+                } else if port == 6381 {
                     return Err(Err(RedisError::from((
                         redis::ErrorKind::ResponseError,
                         "ERROR",
@@ -1805,8 +1806,10 @@ mod cluster_async {
     }
 
     #[test]
-    fn test_async_cluster_one_succeeded_non_empty_return_err_if_all_responses_are_nil_and_errors() {
-        let name = "test_async_cluster_one_succeeded_non_empty_return_err_if_all_responses_are_nil_and_errors";
+    fn test_async_cluster_first_succeeded_non_empty_or_all_empty_return_err_if_all_resps_are_nil_and_errors(
+    ) {
+        let name =
+            "test_async_cluster_first_succeeded_non_empty_or_all_empty_return_err_if_all_resps_are_nil_and_errors";
         let cmd = cmd("RANDOMKEY");
         let MockEnv {
             runtime,
@@ -1819,8 +1822,8 @@ mod cluster_async {
                 .read_from_replicas(),
             name,
             move |received_cmd: &[u8], port| {
-                respond_startup_with_replica_using_config(name, received_cmd, None)?;
-                if port == 6381 {
+                respond_startup_with_config(name, received_cmd, None, false)?;
+                if port == 6380 {
                     return Err(Ok(Value::Nil));
                 }
                 Err(Err(RedisError::from((
@@ -1836,8 +1839,9 @@ mod cluster_async {
     }
 
     #[test]
-    fn test_async_cluster_one_succeeded_non_empty_return_nil_if_all_responses_are_nil() {
-        let name = "test_async_cluster_one_succeeded_non_empty_return_nil_if_all_responses_are_nil";
+    fn test_async_cluster_first_succeeded_non_empty_or_all_empty_return_nil_if_all_resp_nil() {
+        let name =
+            "test_async_cluster_first_succeeded_non_empty_or_all_empty_return_nil_if_all_resp_nil";
         let cmd = cmd("RANDOMKEY");
         let MockEnv {
             runtime,
@@ -1850,7 +1854,7 @@ mod cluster_async {
                 .read_from_replicas(),
             name,
             move |received_cmd: &[u8], _port| {
-                respond_startup_with_replica_using_config(name, received_cmd, None)?;
+                respond_startup_with_config(name, received_cmd, None, false)?;
                 Err(Ok(Value::Nil))
             },
         );

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -1783,7 +1783,9 @@ mod cluster_async {
                 .read_from_replicas(),
             name,
             move |received_cmd: &[u8], port| {
-                respond_startup_with_replica_using_config(name, received_cmd, None)?;
+                let ports = vec![6379, 6380, 6381];
+                let slots_config_vec = generate_topology_view(&ports, 1000, true);
+                respond_startup_with_config(name, received_cmd, Some(slots_config_vec), false)?;
                 if port == 6381 {
                     return Err(Ok(Value::BulkString("foo".as_bytes().to_vec())));
                 } else if port == 6380 {


### PR DESCRIPTION
Attempt to return the first result that isn't `Nil` or an error.
If no such response is found and all servers returned `Nil`, it indicates that all shards are empty, so return `Nil`.
If we received only errors, return the last received error.
If we received a mix of errors and `Nil`s, we can't determine if all shards are empty, thus we return the last received error instead of `Nil`.