### PR TITLE
Added a rate limiter to the slots refresh operations

### DIFF
--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -410,7 +410,7 @@ pub(crate) enum InternalRoutingInfo<C> {
 }
 
 #[derive(PartialEq, Clone, Debug)]
-enum ClientState {
+pub(crate) enum ClientState {
     Initializing,
     Running,
 }

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -94,7 +94,7 @@ use tokio::sync::{
     oneshot::{self, Receiver},
     RwLock,
 };
-use tracing::{info, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 use self::{
     connections_container::{ConnectionAndAddress, ConnectionType, ConnectionsMap},
@@ -1285,7 +1285,10 @@ where
                         // Setting the passed time to 0 will force the current refresh to continue and reset the stored last_run timestamp with the current one
                         Duration::from_secs(0)
                     });
-                if passed_time <= rate_limiter.wait_duration() {
+                let wait_duration = rate_limiter.wait_duration();
+                if passed_time <= wait_duration {
+                    debug!("Skipping slot refreshment as the wait duration hasn't yet passed. Passed time = {:?}, 
+                            Wait duration = {:?}", passed_time, wait_duration);
                     // Skip refreshing the slots since the wait duration (interval + jitter) has not passed
                     return Ok(());
                 }

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -1,11 +1,14 @@
 use crate::cluster_slotmap::ReadFromReplicaStrategy;
-use crate::connection::{
-    ConnectionAddr, ConnectionInfo, IntoConnectionInfo, PubSubSubscriptionInfo,
+#[cfg(feature = "cluster-async")]
+use crate::cluster_topology::{
+    DEFAULT_SLOTS_REFRESH_MAX_JITTER_MILLI, DEFAULT_SLOTS_REFRESH_WAIT_DURATION,
 };
-use crate::push_manager::PushInfo;
+use crate::connection::{ConnectionAddr, ConnectionInfo, IntoConnectionInfo};
 use crate::types::{ErrorKind, ProtocolVersion, RedisError, RedisResult};
 use crate::{cluster, cluster::TlsMode};
 use rand::Rng;
+#[cfg(feature = "cluster-async")]
+use std::ops::Add;
 use std::time::Duration;
 
 #[cfg(feature = "tls-rustls")]
@@ -35,7 +38,10 @@ struct BuilderParams {
     certs: Option<TlsCertificates>,
     retries_configuration: RetryParams,
     connection_timeout: Option<Duration>,
+    #[cfg(feature = "cluster-async")]
     topology_checks_interval: Option<Duration>,
+    #[cfg(feature = "cluster-async")]
+    slots_refresh_rate_limit: SlotsRefreshRateLimit,
     client_name: Option<String>,
     response_timeout: Option<Duration>,
     protocol: ProtocolVersion,
@@ -79,6 +85,42 @@ impl RetryParams {
     }
 }
 
+/// Configuration for rate limiting slot refresh operations in a Redis cluster.
+///
+/// This struct defines the interval duration between consecutive slot refresh
+/// operations and an additional jitter to introduce randomness in the refresh intervals.
+///
+/// # Fields
+///
+/// * `interval_duration`: The minimum duration to wait between consecutive slot refresh operations.
+/// * `max_jitter_milli`: The maximum jitter in milliseconds to add to the interval duration.
+#[cfg(feature = "cluster-async")]
+#[derive(Clone, Copy)]
+pub(crate) struct SlotsRefreshRateLimit {
+    pub(crate) interval_duration: Duration,
+    pub(crate) max_jitter_milli: u64,
+}
+
+#[cfg(feature = "cluster-async")]
+impl Default for SlotsRefreshRateLimit {
+    fn default() -> Self {
+        Self {
+            interval_duration: DEFAULT_SLOTS_REFRESH_WAIT_DURATION,
+            max_jitter_milli: DEFAULT_SLOTS_REFRESH_MAX_JITTER_MILLI,
+        }
+    }
+}
+
+#[cfg(feature = "cluster-async")]
+impl SlotsRefreshRateLimit {
+    pub(crate) fn wait_duration(&self) -> Duration {
+        let duration_jitter = match self.max_jitter_milli {
+            0 => Duration::from_secs(0),
+            _ => Duration::from_millis(rand::thread_rng().gen_range(0..self.max_jitter_milli)),
+        };
+        self.interval_duration.add(duration_jitter)
+    }
+}
 /// Redis cluster specific parameters.
 #[derive(Default, Clone)]
 #[doc(hidden)]
@@ -91,7 +133,10 @@ pub struct ClusterParams {
     /// When None, connections do not use tls.
     pub(crate) tls: Option<TlsMode>,
     pub(crate) retry_params: RetryParams,
+    #[cfg(feature = "cluster-async")]
     pub(crate) topology_checks_interval: Option<Duration>,
+    #[cfg(feature = "cluster-async")]
+    pub(crate) slots_refresh_rate_limit: SlotsRefreshRateLimit,
     pub(crate) tls_params: Option<TlsConnParams>,
     pub(crate) client_name: Option<String>,
     pub(crate) connection_timeout: Duration,
@@ -119,7 +164,10 @@ impl ClusterParams {
             tls: value.tls,
             retry_params: value.retries_configuration,
             connection_timeout: value.connection_timeout.unwrap_or(Duration::MAX),
+            #[cfg(feature = "cluster-async")]
             topology_checks_interval: value.topology_checks_interval,
+            #[cfg(feature = "cluster-async")]
+            slots_refresh_rate_limit: value.slots_refresh_rate_limit,
             tls_params,
             client_name: value.client_name,
             response_timeout: value.response_timeout.unwrap_or(Duration::MAX),
@@ -338,8 +386,44 @@ impl ClusterClientBuilder {
     /// have been any changes in the cluster's topology. If a change is detected, it will trigger a slot refresh.
     /// Unlike slot refreshments, the periodic topology checks only examine a limited number of nodes to query their
     /// topology, ensuring that the check remains quick and efficient.
+    #[cfg(feature = "cluster-async")]
     pub fn periodic_topology_checks(mut self, interval: Duration) -> ClusterClientBuilder {
         self.builder_params.topology_checks_interval = Some(interval);
+        self
+    }
+
+    /// Sets the rate limit for slot refresh operations in the cluster.
+    ///
+    /// This method configures the interval duration between consecutive slot
+    /// refresh operations and an additional jitter to introduce randomness
+    /// in the refresh intervals.
+    ///
+    /// # Parameters
+    ///
+    /// * `interval_duration`: The minimum duration to wait between consecutive slot refresh operations.
+    /// * `max_jitter_milli`: The maximum jitter in milliseconds to add to the interval duration.
+    ///
+    /// # Defaults
+    ///
+    /// If not set, the slots refresh rate limit configurations will be set with the default values:
+    /// ```
+    /// #[cfg(feature = "cluster-async")]
+    /// use redis::cluster_topology::{DEFAULT_SLOTS_REFRESH_MAX_JITTER_MILLI, DEFAULT_SLOTS_REFRESH_WAIT_DURATION};
+    /// ```
+    ///
+    /// - `interval_duration`: `DEFAULT_SLOTS_REFRESH_WAIT_DURATION`
+    /// - `max_jitter_milli`: `DEFAULT_SLOTS_REFRESH_MAX_JITTER_MILLI`
+    ///
+    #[cfg(feature = "cluster-async")]
+    pub fn slots_refresh_rate_limit(
+        mut self,
+        interval_duration: Duration,
+        max_jitter_milli: u64,
+    ) -> ClusterClientBuilder {
+        self.builder_params.slots_refresh_rate_limit = SlotsRefreshRateLimit {
+            interval_duration,
+            max_jitter_milli,
+        };
         self
     }
 
@@ -504,6 +588,11 @@ impl ClusterClient {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "cluster-async")]
+    use crate::cluster_topology::{
+        DEFAULT_SLOTS_REFRESH_MAX_JITTER_MILLI, DEFAULT_SLOTS_REFRESH_WAIT_DURATION,
+    };
+
     use super::{ClusterClient, ClusterClientBuilder, ConnectionInfo, IntoConnectionInfo};
 
     fn get_connection_data() -> Vec<ConnectionInfo> {
@@ -596,5 +685,51 @@ mod tests {
     fn give_empty_initial_nodes() {
         let client = ClusterClient::new(Vec::<String>::new());
         assert!(client.is_err())
+    }
+
+    #[cfg(feature = "cluster-async")]
+    #[test]
+    fn give_slots_refresh_rate_limit_configurations() {
+        let interval_dur = std::time::Duration::from_secs(20);
+        let client = ClusterClientBuilder::new(get_connection_data())
+            .slots_refresh_rate_limit(interval_dur, 500)
+            .build()
+            .unwrap();
+        assert_eq!(
+            client
+                .cluster_params
+                .slots_refresh_rate_limit
+                .interval_duration,
+            interval_dur
+        );
+        assert_eq!(
+            client
+                .cluster_params
+                .slots_refresh_rate_limit
+                .max_jitter_milli,
+            500
+        );
+    }
+
+    #[cfg(feature = "cluster-async")]
+    #[test]
+    fn dont_give_slots_refresh_rate_limit_configurations_uses_defaults() {
+        let client = ClusterClientBuilder::new(get_connection_data())
+            .build()
+            .unwrap();
+        assert_eq!(
+            client
+                .cluster_params
+                .slots_refresh_rate_limit
+                .interval_duration,
+            DEFAULT_SLOTS_REFRESH_WAIT_DURATION
+        );
+        assert_eq!(
+            client
+                .cluster_params
+                .slots_refresh_rate_limit
+                .max_jitter_milli,
+            DEFAULT_SLOTS_REFRESH_MAX_JITTER_MILLI
+        );
     }
 }

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -116,7 +116,7 @@ impl Default for SlotsRefreshRateLimit {
 impl SlotsRefreshRateLimit {
     pub(crate) fn wait_duration(&self) -> Duration {
         let duration_jitter = match self.max_jitter_milli {
-            0 => Duration::from_secs(0),
+            0 => Duration::from_millis(0),
             _ => Duration::from_millis(rand::thread_rng().gen_range(0..self.max_jitter_milli)),
         };
         self.interval_duration.add(duration_jitter)

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -6,6 +6,7 @@ use crate::cluster_topology::{
 use crate::connection::{ConnectionAddr, ConnectionInfo, IntoConnectionInfo};
 use crate::types::{ErrorKind, ProtocolVersion, RedisError, RedisResult};
 use crate::{cluster, cluster::TlsMode};
+use crate::{PubSubSubscriptionInfo, PushInfo};
 use rand::Rng;
 #[cfg(feature = "cluster-async")]
 use std::ops::Add;

--- a/redis/src/cluster_topology.rs
+++ b/redis/src/cluster_topology.rs
@@ -6,13 +6,15 @@ use crate::cluster_client::SlotsRefreshRateLimit;
 use crate::cluster_routing::Slot;
 use crate::cluster_slotmap::{ReadFromReplicaStrategy, SlotMap};
 use crate::{cluster::TlsMode, ErrorKind, RedisError, RedisResult, Value};
+#[cfg(all(feature = "cluster-async", not(feature = "tokio-comp")))]
+use async_std::sync::RwLock;
 use derivative::Derivative;
 use std::collections::{hash_map::DefaultHasher, HashMap};
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
-#[cfg(feature = "cluster-async")]
+#[cfg(all(feature = "cluster-async", feature = "tokio-comp"))]
 use tokio::sync::RwLock;
 
 // Exponential backoff constants for retrying a slot refresh

--- a/redis/src/cluster_topology.rs
+++ b/redis/src/cluster_topology.rs
@@ -1,23 +1,59 @@
 //! This module provides the functionality to refresh and calculate the cluster topology for Redis Cluster.
 
 use crate::cluster::get_connection_addr;
+#[cfg(feature = "cluster-async")]
+use crate::cluster_client::SlotsRefreshRateLimit;
 use crate::cluster_routing::Slot;
 use crate::cluster_slotmap::{ReadFromReplicaStrategy, SlotMap};
 use crate::{cluster::TlsMode, ErrorKind, RedisError, RedisResult, Value};
 use derivative::Derivative;
 use std::collections::{hash_map::DefaultHasher, HashMap};
 use std::hash::{Hash, Hasher};
-use std::time::Duration;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+#[cfg(feature = "cluster-async")]
+use tokio::sync::RwLock;
 
-/// The default number of refersh topology retries
+// Exponential backoff constants for retrying a slot refresh
+/// The default number of refresh topology retries in the same call
 pub const DEFAULT_NUMBER_OF_REFRESH_SLOTS_RETRIES: usize = 3;
-/// The default timeout for retrying topology refresh
-pub const DEFAULT_REFRESH_SLOTS_RETRY_TIMEOUT: Duration = Duration::from_secs(1);
+/// The default maximum interval between two retries of the same call for topology refresh
+pub const DEFAULT_REFRESH_SLOTS_RETRY_MAX_INTERVAL: Duration = Duration::from_secs(1);
 /// The default initial interval for retrying topology refresh
 pub const DEFAULT_REFRESH_SLOTS_RETRY_INITIAL_INTERVAL: Duration = Duration::from_millis(500);
 
+// Constants for the intervals between two independent consecutive refresh slots calls
+/// The default wait duration between two consecutive refresh slots calls
+#[cfg(feature = "cluster-async")]
+pub const DEFAULT_SLOTS_REFRESH_WAIT_DURATION: Duration = Duration::from_secs(15);
+/// The default maximum jitter duration to add to the refresh slots wait duration
+#[cfg(feature = "cluster-async")]
+pub const DEFAULT_SLOTS_REFRESH_MAX_JITTER_MILLI: u64 = 15 * 1000; // 15 seconds
+
 pub(crate) const SLOT_SIZE: u16 = 16384;
 pub(crate) type TopologyHash = u64;
+
+/// Represents the state of slot refresh operations.
+#[cfg(feature = "cluster-async")]
+pub(crate) struct SlotRefreshState {
+    /// Indicates if a slot refresh is currently in progress
+    pub(crate) in_progress: AtomicBool,
+    /// The last slot refresh run timestamp
+    pub(crate) last_run: Arc<RwLock<Option<SystemTime>>>,
+    pub(crate) rate_limiter: SlotsRefreshRateLimit,
+}
+
+#[cfg(feature = "cluster-async")]
+impl SlotRefreshState {
+    pub(crate) fn new(rate_limiter: SlotsRefreshRateLimit) -> Self {
+        Self {
+            in_progress: AtomicBool::new(false),
+            last_run: Arc::new(RwLock::new(None)),
+            rate_limiter,
+        }
+    }
+}
 
 #[derive(Derivative)]
 #[derivative(PartialEq, Eq)]

--- a/redis/src/commands/cluster_scan.rs
+++ b/redis/src/commands/cluster_scan.rs
@@ -1,6 +1,7 @@
 use crate::aio::ConnectionLike;
 use crate::cluster_async::{
-    ClusterConnInner, Connect, Core, InternalRoutingInfo, InternalSingleNodeRouting, Response,
+    ClusterConnInner, Connect, Core, InternalRoutingInfo, InternalSingleNodeRouting,
+    RefreshTrigger, Response,
 };
 use crate::cluster_routing::SlotAddr;
 use crate::cluster_topology::SLOT_SIZE;
@@ -385,7 +386,11 @@ where
         ClusterConnInner::<C>::check_if_all_slots_covered(&self.conn_lock.read().await.slot_map)
     }
     async fn refresh_if_topology_changed(&self) {
-        ClusterConnInner::check_topology_and_refresh_if_diff(self.to_owned()).await;
+        ClusterConnInner::check_topology_and_refresh_if_diff(
+            self.to_owned(),
+            &RefreshTrigger::ScanCmd,
+        )
+        .await;
     }
 }
 

--- a/redis/src/commands/cluster_scan.rs
+++ b/redis/src/commands/cluster_scan.rs
@@ -1,7 +1,7 @@
 use crate::aio::ConnectionLike;
 use crate::cluster_async::{
-    ClusterConnInner, Connect, Core, InternalRoutingInfo, InternalSingleNodeRouting,
-    RefreshTrigger, Response,
+    ClusterConnInner, Connect, Core, InternalRoutingInfo, InternalSingleNodeRouting, RefreshPolicy,
+    Response,
 };
 use crate::cluster_routing::SlotAddr;
 use crate::cluster_topology::SLOT_SIZE;
@@ -388,7 +388,9 @@ where
     async fn refresh_if_topology_changed(&self) {
         ClusterConnInner::check_topology_and_refresh_if_diff(
             self.to_owned(),
-            &RefreshTrigger::ScanCmd,
+            // The cluster SCAN implementation must refresh the slots when a topology change is found
+            // to ensure the scan logic is correct.
+            &RefreshPolicy::NotThrottable,
         )
         .await;
     }

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -1239,7 +1239,9 @@ mod cluster_async {
             handler: _handler,
             ..
         } = MockEnv::with_client_builder(
-            ClusterClient::builder(vec![&*format!("redis://{name}")]).retries(0),
+            ClusterClient::builder(vec![&*format!("redis://{name}")]).retries(0)                
+            // Disable the rate limiter to refresh slots immediately on the MOVED error.
+            .slots_refresh_rate_limit(Duration::from_secs(0), 0),
             name,
             move |cmd: &[u8], port| {
                 if !should_refresh.load(atomic::Ordering::SeqCst) {

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -1398,6 +1398,22 @@ mod cluster_async {
         assert_eq!(
             connection_count_clone.load(Ordering::Relaxed),
             expected_init_calls + 1
+    fn test_async_cluster_refresh_slots_rate_limiter_skips_refresh() {
+        let ports = get_ports(3);
+        test_async_cluster_refresh_slots_rate_limiter_helper(
+            get_topology_with_majority(&ports),
+            ports,
+            true,
+        );
+    }
+
+    #[test]
+    fn test_async_cluster_refresh_slots_rate_limiter_does_refresh_when_wait_duration_passed() {
+        let ports = get_ports(3);
+        test_async_cluster_refresh_slots_rate_limiter_helper(
+            get_topology_with_majority(&ports),
+            ports,
+            false,
         );
     }
 

--- a/redis/tests/test_cluster_scan.rs
+++ b/redis/tests/test_cluster_scan.rs
@@ -7,6 +7,7 @@ mod test_cluster_scan_async {
     use rand::Rng;
     use redis::cluster_routing::{RoutingInfo, SingleNodeRoutingInfo};
     use redis::{cmd, from_redis_value, ObjectType, RedisResult, ScanStateRC, Value};
+    use std::time::Duration;
 
     async fn kill_one_node(
         cluster: &TestClusterContext,
@@ -221,7 +222,12 @@ mod test_cluster_scan_async {
 
     #[tokio::test] // Test cluster scan with killing all masters during scan
     async fn test_async_cluster_scan_with_all_masters_down() {
-        let cluster = TestClusterContext::new(6, 1);
+        let cluster = TestClusterContext::new_with_cluster_client_builder(
+            6,
+            1,
+            |builder| builder.slots_refresh_rate_limit(Duration::from_secs(0), 0),
+            false,
+        );
 
         let mut connection = cluster.async_connection(None).await;
 
@@ -367,7 +373,12 @@ mod test_cluster_scan_async {
     #[tokio::test]
     // Test cluster scan with killing all replicas during scan
     async fn test_async_cluster_scan_with_all_replicas_down() {
-        let cluster = TestClusterContext::new(6, 1);
+        let cluster = TestClusterContext::new_with_cluster_client_builder(
+            6,
+            1,
+            |builder| builder.slots_refresh_rate_limit(Duration::from_secs(0), 0),
+            false,
+        );
 
         let mut connection = cluster.async_connection(None).await;
 


### PR DESCRIPTION
Rebased over #165

This PR introduces a rate limiter to the slots refresh operations, enhancing the efficiency and stability of the system. Consecutive request calls will no longer trigger slot refresh too often, as this is an expensive operation. Note that even when slot refresh is skipped, requests that receive MOVED errors will be immediately routed to the redirect node.

Additionally, this PR adds a new configuration option for the async cluster client: `slots_refresh_rate_limit`. This configuration allows the user to set the wait duration and jitter for rate limiting slot refresh operations, providing greater control over the refresh behavior.

This PR disables the rate limiter for tests that require immediate slot refresh after client creation.