### PR TITLE
Changed the 'url' package version to be fixed to v2.5.0 to enforce license requirements

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -29,7 +29,7 @@ itoa = "1.0"
 percent-encoding = "2.1"
 
 # We need this for redis url parsing
-url = "2.1"
+url = "= 2.5.0"
 
 # We need this for script support
 sha1_smol = { version = "1.0", optional = true }


### PR DESCRIPTION
The url crate has been upgraded to 2.5.1, and it includes the Unicode-3.0 license which is not accepted by rust-lint.
This is now failing on gilde's CI main: https://github.com/aws/glide-for-redis/actions/runs/9452141168/job/26034681086
```
error[rejected]: failed to satisfy license requirements
  ┌─ registry+https://github.com/rust-lang/crates.io-index#icu_properties@1.5.0:4:12
  │
4 │ license = "Unicode-3.0"
  │            ^^^^^^^^^^^
  │            │
  │            license expression retrieved via Cargo.toml `license`
  │            rejected: not explicitly allowed
  │
  = Unicode-3.0 - Unicode License v3:
  =   - OSI approved
  = icu_properties v1.5.0
    ├── icu_normalizer v1.5.0
    │   └── idna v1.0.0
    │       └── url v2.5.1
    │           └── redis v0.25.2
    │               ├── glide-core v0.1.0
    │               │   └── glide-rs v0.1.0
    │               └── glide-rs v0.1.0 (*)
    └── idna v1.0.0 (*)
```
Until we get a response on whether we can use this license, we are fixing the "url" package version to 2.5.0.