### PR TITLE
Added support for aggregating responses for WATCH and UNWATCH

### DIFF
--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -310,7 +310,7 @@ impl ResponsePolicy {
             | b"CLIENT SETINFO" | b"CONFIG SET" | b"CONFIG RESETSTAT" | b"CONFIG REWRITE"
             | b"FLUSHALL" | b"FLUSHDB" | b"FUNCTION DELETE" | b"FUNCTION FLUSH"
             | b"FUNCTION LOAD" | b"FUNCTION RESTORE" | b"MEMORY PURGE" | b"MSET" | b"PING"
-            | b"SCRIPT FLUSH" | b"SCRIPT LOAD" | b"SLOWLOG RESET" => {
+            | b"SCRIPT FLUSH" | b"SCRIPT LOAD" | b"SLOWLOG RESET" | b"UNWATCH" | b"WATCH" => {
                 Some(ResponsePolicy::AllSucceeded)
             }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change is required to support clients to receive one `OK` response for request to clusters. This will make these requests more consistent to commands like `PING`. Related and builds on changes from https://github.com/amazon-contributing/redis-rs/pull/152 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
