### PR TITLE
Fix pubsub doc url to point to valkey

### DIFF
--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -214,7 +214,7 @@ pub struct ConnectionInfo {
 }
 
 /// Types of pubsub subscriptions
-/// See <https://redis.io/docs/interact/pubsub/#sharded-pubsub> for more details
+/// See <https://valkey.io/docs/topics/pubsub> for more details
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Copy)]
 pub enum PubSubSubscriptionKind {
     /// Exact channel name.


### PR DESCRIPTION
*Description of changes:*
Fix pubsub doc url to point to valkey
