### PR TITLE
Changed checks from refreshing slots on each node to periodic check on each node

### DIFF
--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -310,7 +310,7 @@ pub(crate) struct InnerCore<C> {
     pub(crate) conn_lock: RwLock<ConnectionsContainer<C>>,
     cluster_params: ClusterParams,
     pending_requests: Mutex<Vec<PendingRequest<C>>>,
-    pub(crate) slot_refresh_in_progress: AtomicBool,
+    slot_refresh_in_progress: AtomicBool,
     initial_nodes: Vec<ConnectionInfo>,
     push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
     subscriptions_by_address: RwLock<HashMap<ArcStr, PubSubSubscriptionInfo>>,
@@ -383,20 +383,6 @@ where
             .slot_map
             .get_slots_of_node(node_address)
     }
-
-    // Route command to the given address
-    pub(crate) async fn route_command_inner(
-        core: Arc<InnerCore<C>>,
-        cmd: Cmd,
-        address: &str,
-    ) -> RedisResult<Value> {
-        let mut node_conn = ClusterConnInner::get_connection(
-            InternalSingleNodeRouting::ByAddress(address.to_string()),
-            core,
-        )
-        .await?;
-        node_conn.1.req_packed_command(&cmd).await
-    }
 }
 
 pub(crate) struct ClusterConnInner<C> {
@@ -416,7 +402,7 @@ impl<C> Dispose for ClusterConnInner<C> {
 }
 
 #[derive(Clone)]
-enum InternalRoutingInfo<C> {
+pub(crate) enum InternalRoutingInfo<C> {
     SingleNode(InternalSingleNodeRouting<C>),
     MultiNode((MultipleNodeRoutingInfo, Option<ResponsePolicy>)),
 }
@@ -441,7 +427,7 @@ impl<C> From<InternalSingleNodeRouting<C>> for InternalRoutingInfo<C> {
 }
 
 #[derive(Clone)]
-enum InternalSingleNodeRouting<C> {
+pub(crate) enum InternalSingleNodeRouting<C> {
     Random,
     SpecificNode(Route),
     ByAddress(String),
@@ -536,13 +522,13 @@ fn boxed_sleep(duration: Duration) -> BoxFuture<'static, ()> {
     return Box::pin(async_std::task::sleep(duration));
 }
 
-enum Response {
+pub(crate) enum Response {
     Single(Value),
     ClusterScanResult(ScanStateRC, Vec<Value>),
     Multiple(Vec<Value>),
 }
 
-enum OperationTarget {
+pub(crate) enum OperationTarget {
     Node { address: ArcStr },
     FanOut,
     NotFound,
@@ -1040,7 +1026,7 @@ where
         }
     }
 
-    pub(crate) async fn refresh_connections(
+    async fn refresh_connections(
         inner: Arc<InnerCore<C>>,
         addresses: Vec<ArcStr>,
         conn_type: RefreshConnectionType,
@@ -1165,7 +1151,7 @@ where
     }
 
     // Query a node to discover slot-> master mappings with retries
-    pub(crate) async fn refresh_slots_and_subscriptions_with_retries(
+    async fn refresh_slots_and_subscriptions_with_retries(
         inner: Arc<InnerCore<C>>,
     ) -> RedisResult<()> {
         if inner
@@ -1196,6 +1182,15 @@ where
         res
     }
 
+    pub(crate) async fn check_topology_and_refresh_if_diff(inner: Arc<InnerCore<C>>) -> bool {
+        if Self::check_for_topology_diff(inner.clone()).await {
+            let _ = Self::refresh_slots_and_subscriptions_with_retries(inner.clone()).await;
+            true
+        } else {
+            false
+        }
+    }
+
     async fn periodic_topology_check(
         inner: Arc<InnerCore<C>>,
         interval_duration: Duration,
@@ -1207,9 +1202,7 @@ where
             }
             let _ = boxed_sleep(interval_duration).await;
 
-            if Self::check_for_topology_diff(inner.clone()).await {
-                let _ = Self::refresh_slots_and_subscriptions_with_retries(inner.clone()).await;
-            } else {
+            if !Self::check_topology_and_refresh_if_diff(inner.clone()).await {
                 Self::refresh_pubsub_subscriptions(inner.clone()).await;
             }
         }
@@ -1305,7 +1298,7 @@ where
     /// Queries log2n nodes (where n represents the number of cluster nodes) to determine whether their
     /// topology view differs from the one currently stored in the connection manager.
     /// Returns true if change was detected, otherwise false.
-    pub(crate) async fn check_for_topology_diff(inner: Arc<InnerCore<C>>) -> bool {
+    async fn check_for_topology_diff(inner: Arc<InnerCore<C>>) -> bool {
         let read_guard = inner.conn_lock.read().await;
         let num_of_nodes: usize = read_guard.len();
         // TODO: Starting from Rust V1.67, integers has logarithms support.
@@ -1337,7 +1330,7 @@ where
         false
     }
 
-    pub(crate) async fn refresh_slots(
+    async fn refresh_slots(
         inner: Arc<InnerCore<C>>,
         curr_retry: usize,
     ) -> Result<(), BackoffError<RedisError>> {
@@ -1552,7 +1545,7 @@ where
             .map_err(|err| (OperationTarget::FanOut, err))
     }
 
-    async fn try_cmd_request(
+    pub(crate) async fn try_cmd_request(
         cmd: Arc<Cmd>,
         routing: InternalRoutingInfo<C>,
         core: Core<C>,

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -1305,7 +1305,7 @@ where
     /// Queries log2n nodes (where n represents the number of cluster nodes) to determine whether their
     /// topology view differs from the one currently stored in the connection manager.
     /// Returns true if change was detected, otherwise false.
-    async fn check_for_topology_diff(inner: Arc<InnerCore<C>>) -> bool {
+    pub(crate) async fn check_for_topology_diff(inner: Arc<InnerCore<C>>) -> bool {
         let read_guard = inner.conn_lock.read().await;
         let num_of_nodes: usize = read_guard.len();
         // TODO: Starting from Rust V1.67, integers has logarithms support.

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -1616,6 +1616,8 @@ where
                     Ok((scan_state_ref, values)) => {
                         Ok(Response::ClusterScanResult(scan_state_ref, values))
                     }
+                    // TODO: After routing issues with sending to random node on not-key based commands are resolved,
+                    // this error should be handled in the same way as other errors and not fan-out.
                     Err(err) => Err((OperationTarget::FanOut, err)),
                 }
             }

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -1183,12 +1183,11 @@ where
     }
 
     pub(crate) async fn check_topology_and_refresh_if_diff(inner: Arc<InnerCore<C>>) -> bool {
-        if Self::check_for_topology_diff(inner.clone()).await {
+        let topology_changed = Self::check_for_topology_diff(inner.clone()).await;
+        if topology_changed {
             let _ = Self::refresh_slots_and_subscriptions_with_retries(inner.clone()).await;
-            true
-        } else {
-            false
         }
+        topology_changed
     }
 
     async fn periodic_topology_check(
@@ -1201,8 +1200,8 @@ where
                 return;
             }
             let _ = boxed_sleep(interval_duration).await;
-
-            if !Self::check_topology_and_refresh_if_diff(inner.clone()).await {
+            let topology_changed = Self::check_topology_and_refresh_if_diff(inner.clone()).await;
+            if !topology_changed {
                 Self::refresh_pubsub_subscriptions(inner.clone()).await;
             }
         }

--- a/redis/src/commands/cluster_scan.rs
+++ b/redis/src/commands/cluster_scan.rs
@@ -521,6 +521,10 @@ where
             "Not all slots are covered by the cluster, please check the cluster configuration",
         )));
     }
+    // If for some reason we failed to reach the address we don't know if its a scale down or a failover.
+    // Since it might be scale down we cant just keep going with the current state we the same cursor as we are at
+    // the same point in the new address, so we need to get the new address own the next slot that haven't been scanned
+    // and start from the beginning of this address.
     let next_slot = scan_state
         .get_next_slot(&scan_state.scanned_slots_map)
         .unwrap_or(0);


### PR DESCRIPTION
Changed checks from refreshing slots on each node to periodic check on each node

This change decreases the time the scan on a cluster of 150 nodes, 100000 keys, 1000 sets and 1000 hashes to 200ms, while without any check it's taking 100ms.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
