### PR TITLE
Improved client logs

### DIFF
--- a/redis/src/aio/connection.rs
+++ b/redis/src/aio/connection.rs
@@ -28,6 +28,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::pin::Pin;
 #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
 use tokio_util::codec::Decoder;
+use tracing::info;
 
 /// Represents a stateful redis TCP connection.
 #[deprecated(note = "aio::Connection is deprecated. Use aio::MultiplexedConnection instead.")]
@@ -451,6 +452,7 @@ pub(crate) async fn connect_simple<T: RedisRuntime>(
         ConnectionAddr::Tcp(ref host, port) => {
             let socket_addrs = get_socket_addrs(host, port).await?;
             select_ok(socket_addrs.map(|socket_addr| {
+                info!("IP of node {:?} is {:?}", host, socket_addr.ip());
                 Box::pin(async move {
                     Ok::<_, RedisError>((
                         <T>::connect_tcp(socket_addr).await?,
@@ -477,6 +479,7 @@ pub(crate) async fn connect_simple<T: RedisRuntime>(
             }
             let socket_addrs = get_socket_addrs(host, port).await?;
             select_ok(socket_addrs.map(|socket_addr| {
+                info!("IP of node {:?} is {:?}", host, socket_addr.ip());
                 Box::pin(async move {
                     Ok::<_, RedisError>((
                         <T>::connect_tcp_tls(host, socket_addr, insecure, tls_params).await?,

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -794,7 +794,12 @@ impl<C> Future for Request<C> {
                         .into();
                     }
                 };
-                trace!("Request error `{}` on node `{:?}", err, address);
+
+                warn!(
+                    "Request error `{}` on node `{:?}` was caught internally. 
+                    The client will handle it based on the error and its handling policy.",
+                    err, address
+                );
 
                 match err.retry_method() {
                     crate::types::RetryMethod::AskRedirect => {

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -795,11 +795,7 @@ impl<C> Future for Request<C> {
                     }
                 };
 
-                warn!(
-                    "Request error `{}` on node `{:?}` was caught internally. 
-                    The client will handle it based on the error and its handling policy.",
-                    err, address
-                );
+                warn!("Received request error {} on node {:?}.", err, address);
 
                 match err.retry_method() {
                     crate::types::RetryMethod::AskRedirect => {


### PR DESCRIPTION
Change error caught internally to be logged as warnings and added dedicated message to explain to the user that the error is being handled internally. Added a log of the host IP when a new connection is being created.
It's important so we'll be able to help debugging issues for users later on.