### PR TITLE
Reduced the max number of queried nodes in topology request

### DIFF
--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -1489,7 +1489,7 @@ where
     async fn refresh_slots_inner(inner: Arc<InnerCore<C>>, curr_retry: usize) -> RedisResult<()> {
         let read_guard = inner.conn_lock.read().await;
         let num_of_nodes = read_guard.len();
-        const MAX_REQUESTED_NODES: usize = 50;
+        const MAX_REQUESTED_NODES: usize = 10;
         let num_of_nodes_to_query = std::cmp::min(num_of_nodes, MAX_REQUESTED_NODES);
         let (new_slots, topology_hash) = calculate_topology_from_random_nodes(
             &inner,


### PR DESCRIPTION
Reducing the number of max requested nodes in order to be "on the safe side" and reducing the load in large clusters where the CLUSTER SLOTS response can get large.