### PR TITLE
Call to refresh_connections only if failed_conn isn't empty

### DIFF
--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -1447,12 +1447,14 @@ where
         }
         drop(read_guard);
 
-        Self::refresh_connections(
-            inner,
-            failed_connections,
-            RefreshConnectionType::OnlyManagementConnection,
-        )
-        .await;
+        if !failed_connections.is_empty() {
+            Self::refresh_connections(
+                inner,
+                failed_connections,
+                RefreshConnectionType::OnlyManagementConnection,
+            )
+            .await;
+        }
 
         false
     }


### PR DESCRIPTION
ATM refresh connections is being called from each periodic check even when no failed connections were found which resulting in a lot of logs like:
```
[2m2024-07-03T17:07:12.769490Z[0m [32m INFO[0m [2mredis::cluster_async[0m[2m:[0m Started refreshing connections to []
[2m2024-07-03T17:07:12.769523Z[0m [32m INFO[0m [2mredis::cluster_async[0m[2m:[0m refresh connections completed
[2m2024-07-03T17:07:14.331242Z[0m [32m INFO[0m [2mredis::cluster_async[0m[2m:[0m Started refreshing connections to []
[2m2024-07-03T17:07:14.331271Z[0m [32m INFO[0m [2mredis::cluster_async[0m[2m:[0m refresh connections completed
[2m2024-07-03T17:08:12.771693Z[0m [32m INFO[0m [2mredis::cluster_async[0m[2m:[0m Started refreshing connections to []
[2m2024-07-03T17:08:12.771726Z[0m [32m INFO[0m [2mredis::cluster_async[0m[2m:[0m refresh connections completed