### PR TITLE
Allow having connections with different IPs to the same node

### DIFF
--- a/redis/src/aio/connection.rs
+++ b/redis/src/aio/connection.rs
@@ -444,6 +444,7 @@ pub(crate) async fn get_socket_addrs(
     }
 }
 
+/// Logs the creation of a connection, including its type, the node, and optionally its IP address.
 fn log_conn_creation<T>(conn_type: &str, node: T, ip: Option<IpAddr>)
 where
     T: std::fmt::Debug,

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -687,10 +687,10 @@ impl Client {
     ///
     /// - `conn_info` - URL using the `rediss://` scheme.
     /// - `tls_certs` - `TlsCertificates` structure containing:
-    /// -- `client_tls` - Optional `ClientTlsConfig` containing byte streams for
-    /// --- `client_cert` - client's byte stream containing client certificate in PEM format
-    /// --- `client_key` - client's byte stream containing private key in PEM format
-    /// -- `root_cert` - Optional byte stream yielding PEM formatted file for root certificates.
+    ///     -- `client_tls` - Optional `ClientTlsConfig` containing byte streams for
+    ///     --- `client_cert` - client's byte stream containing client certificate in PEM format
+    ///     --- `client_key` - client's byte stream containing private key in PEM format
+    ///     -- `root_cert` - Optional byte stream yielding PEM formatted file for root certificates.
     ///
     /// If `ClientTlsConfig` ( cert+key pair ) is not provided, then client-side authentication is not enabled.
     /// If `root_cert` is not provided, then system root certificates are used instead.

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -150,9 +150,9 @@ where
     /// # Arguments
     ///
     /// * `scan_state_rc` - A reference to the scan state, For initiating new scan send [`ScanStateRC::new()`],
-    /// for each subsequent iteration use the returned [`ScanStateRC`].    
+    ///   for each subsequent iteration use the returned [`ScanStateRC`].    
     /// * `count` - An optional count of keys requested,
-    /// the amount returned can vary and not obligated to return exactly count.
+    ///   the amount returned can vary and not obligated to return exactly count.
     /// * `object_type` - An optional [`ObjectType`] enum of requested key redis type.
     ///
     /// # Returns
@@ -209,10 +209,10 @@ where
     /// # Arguments
     ///
     /// * `scan_state_rc` - A reference to the scan state, For initiating new scan send [`ScanStateRC::new()`],
-    /// for each subsequent iteration use the returned [`ScanStateRC`].
+    ///   for each subsequent iteration use the returned [`ScanStateRC`].
     /// * `match_pattern` - A match pattern of requested keys.
     /// * `count` - An optional count of keys requested,
-    /// the amount returned can vary and not obligated to return exactly count.
+    ///   the amount returned can vary and not obligated to return exactly count.
     /// * `object_type` - An optional [`ObjectType`] enum of requested key redis type.
     ///
     /// # Returns

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -26,6 +26,7 @@ mod connections_container;
 mod connections_logic;
 /// Exposed only for testing.
 pub mod testing {
+    pub use super::connections_container::ConnectionWithIp;
     pub use super::connections_logic::*;
 }
 use crate::{
@@ -1916,7 +1917,7 @@ where
                 .get_node()
                 {
                     Ok(node) => {
-                        let connection_clone = node.user_connection.clone().await;
+                        let connection_clone = node.user_connection.conn.clone().await;
                         let mut connections = core.conn_lock.write().await;
                         let address = connections.replace_or_add_connection_for_address(addr, node);
                         drop(connections);

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -358,10 +358,10 @@ impl ClusterClientBuilder {
     /// checked during `build()` call.
     ///
     /// - `certificates` - `TlsCertificates` structure containing:
-    /// -- `client_tls` - Optional `ClientTlsConfig` containing byte streams for
-    /// --- `client_cert` - client's byte stream containing client certificate in PEM format
-    /// --- `client_key` - client's byte stream containing private key in PEM format
-    /// -- `root_cert` - Optional byte stream yielding PEM formatted file for root certificates.
+    ///   -- `client_tls` - Optional `ClientTlsConfig` containing byte streams for
+    ///   --- `client_cert` - client's byte stream containing client certificate in PEM format
+    ///   --- `client_key` - client's byte stream containing private key in PEM format
+    ///   -- `root_cert` - Optional byte stream yielding PEM formatted file for root certificates.
     ///
     /// If `ClientTlsConfig` ( cert+key pair ) is not provided, then client-side authentication is not enabled.
     /// If `root_cert` is not provided, then system root certificates are used instead.

--- a/redis/src/cluster_topology.rs
+++ b/redis/src/cluster_topology.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 #[cfg(all(feature = "cluster-async", feature = "tokio-comp"))]
 use tokio::sync::RwLock;
+use tracing::info;
 
 // Exponential backoff constants for retrying a slot refresh
 /// The default number of refresh topology retries in the same call
@@ -260,8 +261,11 @@ pub(crate) fn calculate_topology<'a>(
     }
 
     let parse_and_built_result = |most_frequent_topology: TopologyView| {
+        info!(
+            "calculate_topology found topology map:\n{:?}",
+            most_frequent_topology
+        );
         let slots_data = most_frequent_topology.slots_and_count.1;
-
         Ok((
             SlotMap::new(slots_data, read_from_replica),
             most_frequent_topology.hash_value,

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -160,7 +160,7 @@ impl RedisCluster {
                     cmd.arg("--cluster-enabled")
                         .arg("yes")
                         .arg("--cluster-config-file")
-                        .arg(&tempdir.path().join("nodes.conf"))
+                        .arg(tempdir.path().join("nodes.conf"))
                         .arg("--cluster-node-timeout")
                         .arg("5000")
                         .arg("--appendonly")

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -296,7 +296,7 @@ impl RedisServer {
                 // prepare redis with TLS
                 redis_cmd
                     .arg("--tls-port")
-                    .arg(&port.to_string())
+                    .arg(port.to_string())
                     .arg("--port")
                     .arg("0")
                     .arg("--tls-cert-file")

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -938,7 +938,7 @@ mod basic {
         assert_eq!(con.mset(&[("key1", 1), ("key2", 2)]), Ok(()));
         assert_eq!(con.get(&["key1", "key2"]), Ok((1, 2)));
         assert_eq!(con.get(vec!["key1", "key2"]), Ok((1, 2)));
-        assert_eq!(con.get(&vec!["key1", "key2"]), Ok((1, 2)));
+        assert_eq!(con.get(vec!["key1", "key2"]), Ok((1, 2)));
     }
 
     #[test]

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -25,8 +25,8 @@ mod types {
     /// The `FromRedisValue` trait provides two methods for parsing:
     /// - `fn from_redis_value(&Value) -> Result<T, RedisError>`
     /// - `fn from_owned_redis_value(Value) -> Result<T, RedisError>`
-    /// The `RedisParseMode` below allows choosing between the two
-    /// so that test logic does not need to be duplicated for each.
+    ///   The `RedisParseMode` below allows choosing between the two
+    ///   so that test logic does not need to be duplicated for each.
     enum RedisParseMode {
         Owned,
         Ref,


### PR DESCRIPTION
The main purpose of this PR is to allow having connections with different IPs to the same node.

This PR contains three commits:
- Improve logging
- Removed IP checks from the connection logic: On different managed services the given endpoints are actually load balancers and the same DNS entry of a "node" might be routed to different IPs of different LBs. That means that we shouldn't fail the creation of management connection on "mismatched IPs" found between the user and the management connection. 
- Refactored each node connection to be stored with its own IP address. We now use the `ConnectionWithIp` type, which wraps both the actual connection and its associated IP address.