### PR TITLE
Refactored the connections map from HashMap to DashMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,6 +653,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "dashmap"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804c8821570c3f8b70230c2ba75ffa5c0f9a4189b9a432b6656c536712acae28"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1637,6 +1651,7 @@ dependencies = [
  "combine",
  "crc16",
  "criterion",
+ "dashmap",
  "derivative",
  "dispose",
  "fast-math",

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -64,7 +64,7 @@ rand = { version = "0.8", optional = true }
 derivative = { version = "2.2.0", optional = true }
 
 # Only needed for async cluster
-dashmap = { version = "6.0.1", optional = true }
+dashmap = { version = "6.0", optional = true }
 
 # Only needed for async_std support
 async-std = { version = "1.8.0", optional = true }

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -63,6 +63,9 @@ crc16 = { version = "0.4", optional = true }
 rand = { version = "0.8", optional = true }
 derivative = { version = "2.2.0", optional = true }
 
+# Only needed for async cluster
+dashmap = { version = "6.0.1", optional = true }
+
 # Only needed for async_std support
 async-std = { version = "1.8.0", optional = true }
 async-trait = { version = "0.1.24", optional = true }
@@ -124,7 +127,7 @@ tokio-native-tls-comp = ["tokio-comp", "tls-native-tls", "tokio-native-tls"]
 tokio-rustls-comp = ["tokio-comp", "tls-rustls", "tokio-rustls"]
 connection-manager = ["futures", "aio", "tokio-retry"]
 streams = []
-cluster-async = ["cluster", "futures", "futures-util"]
+cluster-async = ["cluster", "futures", "futures-util", "dashmap"]
 keep-alive = ["socket2"]
 sentinel = ["rand"]
 tcp_nodelay = []

--- a/redis/src/cluster_async/connections_container.rs
+++ b/redis/src/cluster_async/connections_container.rs
@@ -309,8 +309,8 @@ mod tests {
             }
         }
     }
-    fn remove_nodes(container: &ConnectionsContainer<usize>, addresss: &[&str]) {
-        for address in addresss {
+    fn remove_nodes(container: &ConnectionsContainer<usize>, addresses: &[&str]) {
+        for address in addresses {
             container.remove_node(&(*address).into());
         }
     }

--- a/redis/src/cluster_async/connections_container.rs
+++ b/redis/src/cluster_async/connections_container.rs
@@ -2,7 +2,6 @@ use crate::cluster_async::ConnectionFuture;
 use crate::cluster_routing::{Route, SlotAddr};
 use crate::cluster_slotmap::{ReadFromReplicaStrategy, SlotMap, SlotMapValue};
 use crate::cluster_topology::TopologyHash;
-use arcstr::ArcStr;
 use dashmap::DashMap;
 use futures::FutureExt;
 use rand::seq::IteratorRandom;
@@ -85,7 +84,7 @@ pub(crate) enum ConnectionType {
     PreferManagement,
 }
 
-pub(crate) struct ConnectionsMap<Connection>(pub(crate) DashMap<ArcStr, ClusterNode<Connection>>);
+pub(crate) struct ConnectionsMap<Connection>(pub(crate) DashMap<String, ClusterNode<Connection>>);
 
 impl<Connection> std::fmt::Display for ConnectionsMap<Connection> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -101,7 +100,7 @@ impl<Connection> std::fmt::Display for ConnectionsMap<Connection> {
 }
 
 pub(crate) struct ConnectionsContainer<Connection> {
-    connection_map: DashMap<ArcStr, ClusterNode<Connection>>,
+    connection_map: DashMap<String, ClusterNode<Connection>>,
     pub(crate) slot_map: SlotMap,
     read_from_replica_strategy: ReadFromReplicaStrategy,
     topology_hash: TopologyHash,
@@ -118,7 +117,7 @@ impl<Connection> Default for ConnectionsContainer<Connection> {
     }
 }
 
-pub(crate) type ConnectionAndAddress<Connection> = (ArcStr, Connection);
+pub(crate) type ConnectionAndAddress<Connection> = (String, Connection);
 
 impl<Connection> ConnectionsContainer<Connection>
 where
@@ -139,7 +138,7 @@ where
     }
 
     /// Returns true if the address represents a known primary node.
-    pub(crate) fn is_primary(&self, address: &ArcStr) -> bool {
+    pub(crate) fn is_primary(&self, address: &String) -> bool {
         self.connection_for_address(address).is_some()
             && self
                 .slot_map
@@ -262,15 +261,15 @@ where
 
     pub(crate) fn replace_or_add_connection_for_address(
         &self,
-        address: impl Into<ArcStr>,
+        address: impl Into<String>,
         node: ClusterNode<Connection>,
-    ) -> ArcStr {
+    ) -> String {
         let address = address.into();
         self.connection_map.insert(address.clone(), node);
         address
     }
 
-    pub(crate) fn remove_node(&self, address: &ArcStr) -> Option<ClusterNode<Connection>> {
+    pub(crate) fn remove_node(&self, address: &String) -> Option<ClusterNode<Connection>> {
         self.connection_map
             .remove(address)
             .map(|(_key, value)| value)


### PR DESCRIPTION
This PR changes the connection map data structure to DashMap, which helps reduce write lock contention on the connection container. The write lock on the connection container now will only be used when both slots and connection maps are being replaced.