### PR TITLE
Handle SPUBLISH as a non key-based command

### DIFF
--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -1868,7 +1868,7 @@ where
                         //   (e.g., sending management command to a different node than the user asked for); instead, raise the error.
                         let routable_cmd = cmd.and_then(|cmd| Routable::command(&*cmd));
                         if routable_cmd.is_some()
-                            && !RoutingInfo::is_key_based_cmd(&routable_cmd.unwrap())
+                            && !RoutingInfo::is_key_routing_command(&routable_cmd.unwrap())
                         {
                             return Err((
                                 ErrorKind::ClusterConnectionNotFound,


### PR DESCRIPTION
This change ensures that SPUBLISH messages won’t be redirected to a random node if the intended target node isn’t available. The optimization of routing to a random node should only apply to commands that return a MOVED error if the target node isn’t the slot owner. The issue with SPUBLISH is that its behavior is unpredictable when redirected: if the randomly chosen node is outside the slot’s shard, a MOVED error will be returned; otherwise, the command might succeed, leading to inconsistent behavior. To address this, we will implement a PRIMARY_PREFERRED routing strategy for SPUBLISH, deliberately routing failed SPUBLISH commands to other nodes within the same shard.