### PR TITLE
Introduce a fast reconnect process for async cluster connections.

### DIFF
--- a/redis-test/src/lib.rs
+++ b/redis-test/src/lib.rs
@@ -288,6 +288,10 @@ impl AioConnectionLike for MockRedisConnection {
     fn get_db(&self) -> i64 {
         0
     }
+
+    fn is_closed(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/redis/examples/async-await.rs
+++ b/redis/examples/async-await.rs
@@ -1,10 +1,12 @@
 #![allow(unknown_lints, dependency_on_unit_never_type_fallback)]
-use redis::AsyncCommands;
+use redis::{AsyncCommands, GlideConnectionOptions};
 
 #[tokio::main]
 async fn main() -> redis::RedisResult<()> {
     let client = redis::Client::open("redis://127.0.0.1/").unwrap();
-    let mut con = client.get_multiplexed_async_connection(None, None).await?;
+    let mut con = client
+        .get_multiplexed_async_connection(GlideConnectionOptions::default())
+        .await?;
 
     con.set("key1", b"foo").await?;
 

--- a/redis/examples/async-await.rs
+++ b/redis/examples/async-await.rs
@@ -4,7 +4,7 @@ use redis::AsyncCommands;
 #[tokio::main]
 async fn main() -> redis::RedisResult<()> {
     let client = redis::Client::open("redis://127.0.0.1/").unwrap();
-    let mut con = client.get_multiplexed_async_connection(None).await?;
+    let mut con = client.get_multiplexed_async_connection(None, None).await?;
 
     con.set("key1", b"foo").await?;
 

--- a/redis/examples/async-connection-loss.rs
+++ b/redis/examples/async-connection-loss.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 
 use futures::future;
 use redis::aio::ConnectionLike;
+use redis::GlideConnectionOptions;
 use redis::RedisResult;
 use tokio::time::interval;
 
@@ -81,7 +82,12 @@ async fn main() -> RedisResult<()> {
     let client = redis::Client::open("redis://127.0.0.1/").unwrap();
     match mode {
         Mode::Default => {
-            run_multi(client.get_multiplexed_tokio_connection(None, None).await?).await?
+            run_multi(
+                client
+                    .get_multiplexed_tokio_connection(GlideConnectionOptions::default())
+                    .await?,
+            )
+            .await?
         }
         Mode::Reconnect => run_multi(client.get_connection_manager().await?).await?,
         #[allow(deprecated)]

--- a/redis/examples/async-connection-loss.rs
+++ b/redis/examples/async-connection-loss.rs
@@ -80,7 +80,9 @@ async fn main() -> RedisResult<()> {
 
     let client = redis::Client::open("redis://127.0.0.1/").unwrap();
     match mode {
-        Mode::Default => run_multi(client.get_multiplexed_tokio_connection(None).await?).await?,
+        Mode::Default => {
+            run_multi(client.get_multiplexed_tokio_connection(None, None).await?).await?
+        }
         Mode::Reconnect => run_multi(client.get_connection_manager().await?).await?,
         #[allow(deprecated)]
         Mode::Deprecated => run_single(client.get_async_connection(None).await?).await?,

--- a/redis/examples/async-multiplexed.rs
+++ b/redis/examples/async-multiplexed.rs
@@ -1,6 +1,6 @@
 #![allow(unknown_lints, dependency_on_unit_never_type_fallback)]
 use futures::prelude::*;
-use redis::{aio::MultiplexedConnection, RedisResult};
+use redis::{aio::MultiplexedConnection, GlideConnectionOptions, RedisResult};
 
 async fn test_cmd(con: &MultiplexedConnection, i: i32) -> RedisResult<()> {
     let mut con = con.clone();
@@ -35,7 +35,7 @@ async fn main() {
     let client = redis::Client::open("redis://127.0.0.1/").unwrap();
 
     let con = client
-        .get_multiplexed_tokio_connection(None, None)
+        .get_multiplexed_tokio_connection(GlideConnectionOptions::default())
         .await
         .unwrap();
 

--- a/redis/examples/async-multiplexed.rs
+++ b/redis/examples/async-multiplexed.rs
@@ -34,7 +34,10 @@ async fn test_cmd(con: &MultiplexedConnection, i: i32) -> RedisResult<()> {
 async fn main() {
     let client = redis::Client::open("redis://127.0.0.1/").unwrap();
 
-    let con = client.get_multiplexed_tokio_connection(None).await.unwrap();
+    let con = client
+        .get_multiplexed_tokio_connection(None, None)
+        .await
+        .unwrap();
 
     let cmds = (0..100).map(|i| test_cmd(&con, i));
     let result = future::try_join_all(cmds).await.unwrap();

--- a/redis/examples/async-pub-sub.rs
+++ b/redis/examples/async-pub-sub.rs
@@ -5,7 +5,7 @@ use redis::AsyncCommands;
 #[tokio::main]
 async fn main() -> redis::RedisResult<()> {
     let client = redis::Client::open("redis://127.0.0.1/").unwrap();
-    let mut publish_conn = client.get_multiplexed_async_connection(None).await?;
+    let mut publish_conn = client.get_multiplexed_async_connection(None, None).await?;
     let mut pubsub_conn = client.get_async_pubsub().await?;
 
     pubsub_conn.subscribe("wavephone").await?;

--- a/redis/examples/async-pub-sub.rs
+++ b/redis/examples/async-pub-sub.rs
@@ -1,11 +1,13 @@
 #![allow(unknown_lints, dependency_on_unit_never_type_fallback)]
 use futures_util::StreamExt as _;
-use redis::AsyncCommands;
+use redis::{AsyncCommands, GlideConnectionOptions};
 
 #[tokio::main]
 async fn main() -> redis::RedisResult<()> {
     let client = redis::Client::open("redis://127.0.0.1/").unwrap();
-    let mut publish_conn = client.get_multiplexed_async_connection(None, None).await?;
+    let mut publish_conn = client
+        .get_multiplexed_async_connection(GlideConnectionOptions::default())
+        .await?;
     let mut pubsub_conn = client.get_async_pubsub().await?;
 
     pubsub_conn.subscribe("wavephone").await?;

--- a/redis/examples/async-scan.rs
+++ b/redis/examples/async-scan.rs
@@ -5,7 +5,7 @@ use redis::{AsyncCommands, AsyncIter};
 #[tokio::main]
 async fn main() -> redis::RedisResult<()> {
     let client = redis::Client::open("redis://127.0.0.1/").unwrap();
-    let mut con = client.get_multiplexed_async_connection(None).await?;
+    let mut con = client.get_multiplexed_async_connection(None, None).await?;
 
     con.set("async-key1", b"foo").await?;
     con.set("async-key2", b"foo").await?;

--- a/redis/examples/async-scan.rs
+++ b/redis/examples/async-scan.rs
@@ -1,11 +1,13 @@
 #![allow(unknown_lints, dependency_on_unit_never_type_fallback)]
 use futures::stream::StreamExt;
-use redis::{AsyncCommands, AsyncIter};
+use redis::{AsyncCommands, AsyncIter, GlideConnectionOptions};
 
 #[tokio::main]
 async fn main() -> redis::RedisResult<()> {
     let client = redis::Client::open("redis://127.0.0.1/").unwrap();
-    let mut con = client.get_multiplexed_async_connection(None, None).await?;
+    let mut con = client
+        .get_multiplexed_async_connection(GlideConnectionOptions::default())
+        .await?;
 
     con.set("async-key1", b"foo").await?;
     con.set("async-key2", b"foo").await?;

--- a/redis/src/aio/connection.rs
+++ b/redis/src/aio/connection.rs
@@ -305,6 +305,11 @@ where
     fn get_db(&self) -> i64 {
         self.db
     }
+
+    fn is_closed(&self) -> bool {
+        // always false for AsyncRead + AsyncWrite (cant do better)
+        false
+    }
 }
 
 /// Represents a `PubSub` connection.

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -196,6 +196,7 @@ impl ConnectionManager {
                 response_timeout,
                 connection_timeout,
                 None,
+                None,
             )
         })
         .await
@@ -300,5 +301,10 @@ impl ConnectionLike for ConnectionManager {
 
     fn get_db(&self) -> i64 {
         self.client.connection_info().redis.db
+    }
+
+    fn is_closed(&self) -> bool {
+        // always return false due to automatic reconnect
+        false
     }
 }

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -1,4 +1,5 @@
 use super::RedisFuture;
+use crate::client::GlideConnectionOptions;
 use crate::cmd::Cmd;
 use crate::push_manager::PushManager;
 use crate::types::{RedisError, RedisResult, Value};
@@ -195,8 +196,7 @@ impl ConnectionManager {
             client.get_multiplexed_async_connection_with_timeouts(
                 response_timeout,
                 connection_timeout,
-                None,
-                None,
+                GlideConnectionOptions::default(),
             )
         })
         .await

--- a/redis/src/aio/mod.rs
+++ b/redis/src/aio/mod.rs
@@ -85,6 +85,24 @@ pub trait ConnectionLike {
     /// also might be incorrect if the connection like object is not
     /// actually connected.
     fn get_db(&self) -> i64;
+
+    /// Returns the state of the connection
+    fn is_closed(&self) -> bool;
+}
+
+/// Implements ability to notify about disconnection events
+pub trait DisconnectNotifier: Send + Sync {
+    /// Notify about disconnect event
+    fn notify_disconnect(&mut self);
+
+    /// Intended to be used with Box
+    fn clone_box(&self) -> Box<dyn DisconnectNotifier>;
+}
+
+impl Clone for Box<dyn DisconnectNotifier> {
+    fn clone(&self) -> Box<dyn DisconnectNotifier> {
+        self.clone_box()
+    }
 }
 
 // Initial setup for every connection.

--- a/redis/src/aio/mod.rs
+++ b/redis/src/aio/mod.rs
@@ -12,6 +12,7 @@ use std::net::SocketAddr;
 #[cfg(unix)]
 use std::path::Path;
 use std::pin::Pin;
+use std::time::Duration;
 
 /// Enables the async_std compatibility
 #[cfg(feature = "async-std-comp")]
@@ -91,9 +92,13 @@ pub trait ConnectionLike {
 }
 
 /// Implements ability to notify about disconnection events
+#[async_trait]
 pub trait DisconnectNotifier: Send + Sync {
     /// Notify about disconnect event
     fn notify_disconnect(&mut self);
+
+    /// Wait for disconnect event with timeout
+    async fn wait_for_disconnect_with_timeout(&self, max_wait: &Duration);
 
     /// Intended to be used with Box
     fn clone_box(&self) -> Box<dyn DisconnectNotifier>;

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -78,6 +78,16 @@ impl Client {
     }
 }
 
+/// Glide-specific connection options
+#[derive(Clone, Default)]
+pub struct GlideConnectionOptions {
+    /// Queue for RESP3 notifications
+    pub push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
+    #[cfg(feature = "aio")]
+    /// Passive disconnect notifier
+    pub disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
+}
+
 /// To enable async support you need to chose one of the supported runtimes and active its
 /// corresponding feature: `tokio-comp` or `async-std-comp`
 #[cfg(feature = "aio")]
@@ -149,14 +159,12 @@ impl Client {
     )]
     pub async fn get_multiplexed_async_connection(
         &self,
-        push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
-        disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
+        glide_connection_options: GlideConnectionOptions,
     ) -> RedisResult<crate::aio::MultiplexedConnection> {
         self.get_multiplexed_async_connection_with_timeouts(
             std::time::Duration::MAX,
             std::time::Duration::MAX,
-            push_sender,
-            disconnect_notifier,
+            glide_connection_options,
         )
         .await
     }
@@ -171,8 +179,7 @@ impl Client {
         &self,
         response_timeout: std::time::Duration,
         connection_timeout: std::time::Duration,
-        push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
-        disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
+        glide_connection_options: GlideConnectionOptions,
     ) -> RedisResult<crate::aio::MultiplexedConnection> {
         let result = match Runtime::locate() {
             #[cfg(feature = "tokio-comp")]
@@ -182,8 +189,7 @@ impl Client {
                     self.get_multiplexed_async_connection_inner::<crate::aio::tokio::Tokio>(
                         response_timeout,
                         None,
-                        push_sender,
-                        disconnect_notifier,
+                        glide_connection_options,
                     ),
                 )
                 .await
@@ -195,8 +201,7 @@ impl Client {
                     self.get_multiplexed_async_connection_inner::<crate::aio::async_std::AsyncStd>(
                         response_timeout,
                         None,
-                        push_sender,
-                        disconnect_notifier,
+                        glide_connection_options,
                     ),
                 )
                 .await
@@ -220,8 +225,7 @@ impl Client {
     )]
     pub async fn get_multiplexed_async_connection_and_ip(
         &self,
-        push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
-        disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
+        glide_connection_options: GlideConnectionOptions,
     ) -> RedisResult<(crate::aio::MultiplexedConnection, Option<IpAddr>)> {
         match Runtime::locate() {
             #[cfg(feature = "tokio-comp")]
@@ -229,8 +233,7 @@ impl Client {
                 self.get_multiplexed_async_connection_inner::<crate::aio::tokio::Tokio>(
                     Duration::MAX,
                     None,
-                    push_sender,
-                    disconnect_notifier,
+                    glide_connection_options,
                 )
                 .await
             }
@@ -239,8 +242,7 @@ impl Client {
                 self.get_multiplexed_async_connection_inner::<crate::aio::async_std::AsyncStd>(
                     Duration::MAX,
                     None,
-                    push_sender,
-                    disconnect_notifier,
+                    glide_connection_options,
                 )
                 .await
             }
@@ -257,8 +259,7 @@ impl Client {
         &self,
         response_timeout: std::time::Duration,
         connection_timeout: std::time::Duration,
-        push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
-        disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
+        glide_connection_options: GlideConnectionOptions,
     ) -> RedisResult<crate::aio::MultiplexedConnection> {
         let result = Runtime::locate()
             .timeout(
@@ -266,8 +267,7 @@ impl Client {
                 self.get_multiplexed_async_connection_inner::<crate::aio::tokio::Tokio>(
                     response_timeout,
                     None,
-                    push_sender,
-                    disconnect_notifier,
+                    glide_connection_options,
                 ),
             )
             .await;
@@ -287,14 +287,12 @@ impl Client {
     #[cfg_attr(docsrs, doc(cfg(feature = "tokio-comp")))]
     pub async fn get_multiplexed_tokio_connection(
         &self,
-        push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
-        disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
+        glide_connection_options: GlideConnectionOptions,
     ) -> RedisResult<crate::aio::MultiplexedConnection> {
         self.get_multiplexed_tokio_connection_with_response_timeouts(
             std::time::Duration::MAX,
             std::time::Duration::MAX,
-            push_sender,
-            disconnect_notifier,
+            glide_connection_options,
         )
         .await
     }
@@ -309,8 +307,7 @@ impl Client {
         &self,
         response_timeout: std::time::Duration,
         connection_timeout: std::time::Duration,
-        push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
-        disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
+        glide_connection_options: GlideConnectionOptions,
     ) -> RedisResult<crate::aio::MultiplexedConnection> {
         let result = Runtime::locate()
             .timeout(
@@ -318,8 +315,7 @@ impl Client {
                 self.get_multiplexed_async_connection_inner::<crate::aio::async_std::AsyncStd>(
                     response_timeout,
                     None,
-                    push_sender,
-                    disconnect_notifier,
+                    glide_connection_options,
                 ),
             )
             .await;
@@ -339,14 +335,12 @@ impl Client {
     #[cfg_attr(docsrs, doc(cfg(feature = "async-std-comp")))]
     pub async fn get_multiplexed_async_std_connection(
         &self,
-        push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
-        disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
+        glide_connection_options: GlideConnectionOptions,
     ) -> RedisResult<crate::aio::MultiplexedConnection> {
         self.get_multiplexed_async_std_connection_with_timeouts(
             std::time::Duration::MAX,
             std::time::Duration::MAX,
-            push_sender,
-            disconnect_notifier,
+            glide_connection_options,
         )
         .await
     }
@@ -362,8 +356,7 @@ impl Client {
     pub async fn create_multiplexed_tokio_connection_with_response_timeout(
         &self,
         response_timeout: std::time::Duration,
-        push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
-        disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
+        glide_connection_options: GlideConnectionOptions,
     ) -> RedisResult<(
         crate::aio::MultiplexedConnection,
         impl std::future::Future<Output = ()>,
@@ -371,8 +364,7 @@ impl Client {
         self.create_multiplexed_async_connection_inner::<crate::aio::tokio::Tokio>(
             response_timeout,
             None,
-            push_sender,
-            disconnect_notifier,
+            glide_connection_options,
         )
         .await
         .map(|(conn, driver, _ip)| (conn, driver))
@@ -387,16 +379,14 @@ impl Client {
     #[cfg_attr(docsrs, doc(cfg(feature = "tokio-comp")))]
     pub async fn create_multiplexed_tokio_connection(
         &self,
-        push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
-        disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
+        glide_connection_options: GlideConnectionOptions,
     ) -> RedisResult<(
         crate::aio::MultiplexedConnection,
         impl std::future::Future<Output = ()>,
     )> {
         self.create_multiplexed_tokio_connection_with_response_timeout(
             std::time::Duration::MAX,
-            push_sender,
-            disconnect_notifier,
+            glide_connection_options,
         )
         .await
         .map(|conn_res| (conn_res.0, conn_res.1))
@@ -413,8 +403,7 @@ impl Client {
     pub async fn create_multiplexed_async_std_connection_with_response_timeout(
         &self,
         response_timeout: std::time::Duration,
-        push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
-        disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
+        glide_connection_options: GlideConnectionOptions,
     ) -> RedisResult<(
         crate::aio::MultiplexedConnection,
         impl std::future::Future<Output = ()>,
@@ -422,8 +411,7 @@ impl Client {
         self.create_multiplexed_async_connection_inner::<crate::aio::async_std::AsyncStd>(
             response_timeout,
             None,
-            push_sender,
-            disconnect_notifier,
+            glide_connection_options,
         )
         .await
         .map(|(conn, driver, _ip)| (conn, driver))
@@ -438,16 +426,14 @@ impl Client {
     #[cfg_attr(docsrs, doc(cfg(feature = "async-std-comp")))]
     pub async fn create_multiplexed_async_std_connection(
         &self,
-        push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
-        disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
+        glide_connection_options: GlideConnectionOptions,
     ) -> RedisResult<(
         crate::aio::MultiplexedConnection,
         impl std::future::Future<Output = ()>,
     )> {
         self.create_multiplexed_async_std_connection_with_response_timeout(
             std::time::Duration::MAX,
-            push_sender,
-            disconnect_notifier,
+            glide_connection_options,
         )
         .await
     }
@@ -650,8 +636,7 @@ impl Client {
         &self,
         response_timeout: std::time::Duration,
         socket_addr: Option<SocketAddr>,
-        push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
-        disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
+        glide_connection_options: GlideConnectionOptions,
     ) -> RedisResult<(crate::aio::MultiplexedConnection, Option<IpAddr>)>
     where
         T: crate::aio::RedisRuntime,
@@ -660,8 +645,7 @@ impl Client {
             .create_multiplexed_async_connection_inner::<T>(
                 response_timeout,
                 socket_addr,
-                push_sender,
-                disconnect_notifier,
+                glide_connection_options,
             )
             .await?;
         T::spawn(driver);
@@ -672,8 +656,7 @@ impl Client {
         &self,
         response_timeout: std::time::Duration,
         socket_addr: Option<SocketAddr>,
-        push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
-        disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
+        glide_connection_options: GlideConnectionOptions,
     ) -> RedisResult<(
         crate::aio::MultiplexedConnection,
         impl std::future::Future<Output = ()>,
@@ -687,8 +670,7 @@ impl Client {
             &self.connection_info,
             con,
             response_timeout,
-            push_sender,
-            disconnect_notifier,
+            glide_connection_options,
         )
         .await
         .map(|res| (res.0, res.1, ip))

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -58,7 +58,7 @@ use std::{
 use tokio::task::JoinHandle;
 
 use crate::{
-    aio::{get_socket_addrs, ConnectionLike, MultiplexedConnection, Runtime},
+    aio::{get_socket_addrs, ConnectionLike, DisconnectNotifier, MultiplexedConnection, Runtime},
     cluster::slot_cmd,
     cluster_async::connections_logic::{
         get_host_and_port_from_addr, get_or_create_conn, ConnectionFuture, RefreshConnectionType,
@@ -91,6 +91,8 @@ use backoff_std_async::{Error as BackoffError, ExponentialBackoff};
 use backoff_tokio::future::retry;
 #[cfg(feature = "tokio-comp")]
 use backoff_tokio::{Error as BackoffError, ExponentialBackoff};
+#[cfg(feature = "tokio-comp")]
+use tokio::{sync::Notify, time::timeout};
 
 use dispose::{Disposable, Dispose};
 use futures::{future::BoxFuture, prelude::*, ready};
@@ -370,6 +372,23 @@ where
     }
 }
 
+#[cfg(feature = "tokio-comp")]
+#[derive(Clone)]
+struct TokioDisconnectNotifier {
+    pub disconnect_notifier: Arc<Notify>,
+}
+
+#[cfg(feature = "tokio-comp")]
+impl DisconnectNotifier for TokioDisconnectNotifier {
+    fn notify_disconnect(&mut self) {
+        self.disconnect_notifier.notify_one();
+    }
+
+    fn clone_box(&self) -> Box<dyn DisconnectNotifier> {
+        Box::new(self.clone())
+    }
+}
+
 type ConnectionMap<C> = connections_container::ConnectionsMap<ConnectionFuture<C>>;
 type ConnectionsContainer<C> =
     self::connections_container::ConnectionsContainer<ConnectionFuture<C>>;
@@ -383,6 +402,9 @@ pub(crate) struct InnerCore<C> {
     push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
     subscriptions_by_address: RwLock<HashMap<String, PubSubSubscriptionInfo>>,
     unassigned_subscriptions: RwLock<PubSubSubscriptionInfo>,
+    disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
+    #[cfg(feature = "tokio-comp")]
+    tokio_notify: Arc<Notify>,
 }
 
 pub(crate) type Core<C> = Arc<InnerCore<C>>;
@@ -461,11 +483,19 @@ pub(crate) struct ClusterConnInner<C> {
     refresh_error: Option<RedisError>,
     // Handler of the periodic check task.
     periodic_checks_handler: Option<JoinHandle<()>>,
+    // Handler of fast connection validation task
+    connections_validation_handler: Option<JoinHandle<()>>,
 }
 
 impl<C> Dispose for ClusterConnInner<C> {
     fn dispose(self) {
         if let Some(handle) = self.periodic_checks_handler {
+            #[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
+            block_on(handle.cancel());
+            #[cfg(feature = "tokio-comp")]
+            handle.abort()
+        }
+        if let Some(handle) = self.connections_validation_handler {
             #[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
             block_on(handle.cancel());
             #[cfg(feature = "tokio-comp")]
@@ -957,9 +987,27 @@ where
         cluster_params: ClusterParams,
         push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
     ) -> RedisResult<Disposable<Self>> {
-        let connections =
-            Self::create_initial_connections(initial_nodes, &cluster_params, push_sender.clone())
-                .await?;
+        #[cfg(feature = "tokio-comp")]
+        let tokio_notify = Arc::new(Notify::new());
+
+        let disconnect_notifier = {
+            #[cfg(feature = "tokio-comp")]
+            {
+                Some::<Box<dyn DisconnectNotifier>>(Box::new(TokioDisconnectNotifier {
+                    disconnect_notifier: tokio_notify.clone(),
+                }))
+            }
+            #[cfg(not(feature = "tokio-comp"))]
+            None
+        };
+
+        let connections = Self::create_initial_connections(
+            initial_nodes,
+            &cluster_params,
+            push_sender.clone(),
+            disconnect_notifier.clone(),
+        )
+        .await?;
 
         let topology_checks_interval = cluster_params.topology_checks_interval;
         let slots_refresh_rate_limiter = cluster_params.slots_refresh_rate_limit;
@@ -983,6 +1031,9 @@ where
                 },
             ),
             subscriptions_by_address: RwLock::new(Default::default()),
+            disconnect_notifier: disconnect_notifier.clone(),
+            #[cfg(feature = "tokio-comp")]
+            tokio_notify,
         });
         let mut connection = ClusterConnInner {
             inner,
@@ -990,6 +1041,7 @@ where
             refresh_error: None,
             state: ConnectionState::PollComplete,
             periodic_checks_handler: None,
+            connections_validation_handler: None,
         };
         Self::refresh_slots_and_subscriptions_with_retries(
             connection.inner.clone(),
@@ -1007,6 +1059,22 @@ where
             #[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
             {
                 connection.periodic_checks_handler = Some(spawn(periodic_task));
+            }
+        }
+
+        let connections_validation_interval = cluster_params.connections_validation_interval;
+        if let Some(duration) = connections_validation_interval {
+            let connections_validation_handler =
+                ClusterConnInner::connections_validation_task(connection.inner.clone(), duration);
+            #[cfg(feature = "tokio-comp")]
+            {
+                connection.connections_validation_handler =
+                    Some(tokio::spawn(connections_validation_handler));
+            }
+            #[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
+            {
+                connection.connections_validation_handler =
+                    Some(spawn(connections_validation_handler));
             }
         }
 
@@ -1058,6 +1126,7 @@ where
         initial_nodes: &[ConnectionInfo],
         params: &ClusterParams,
         push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
+        disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
     ) -> RedisResult<ConnectionMap<C>> {
         let initial_nodes: Vec<(String, Option<SocketAddr>)> =
             Self::try_to_expand_initial_nodes(initial_nodes).await;
@@ -1067,6 +1136,7 @@ where
                 let push_sender = push_sender.clone();
                 // set subscriptions to none, they will be applied upon the topology discovery
                 params.pubsub_subscriptions = None;
+                let disconnect_notifier = disconnect_notifier.clone();
 
                 async move {
                     let result = connect_and_check(
@@ -1076,6 +1146,7 @@ where
                         RefreshConnectionType::AllConnections,
                         None,
                         push_sender,
+                        disconnect_notifier,
                     )
                     .await
                     .get_node();
@@ -1122,6 +1193,7 @@ where
                 &inner.initial_nodes,
                 &inner.cluster_params,
                 None,
+                inner.disconnect_notifier.clone(),
             )
             .await
             {
@@ -1145,22 +1217,93 @@ where
         }
     }
 
+    // Validate all existing user connections and try to reconnect if nessesary.
+    // In addition, as a safety measure, drop nodes that do not have any assigned slots.
+    // This function serves as a cheap alternative to slot_refresh() and thus can be used much more frequently.
+    // The function does not discover the topology from the cluster and assumes the cached topology is valid.
+    // In addition, the validation is done by peeking at the state of the underlying transport w/o overhead of additional commands to server.
+    async fn validate_all_user_connections(inner: Arc<InnerCore<C>>) {
+        let mut all_valid_conns = HashMap::new();
+        let mut all_nodes_with_slots = HashSet::new();
+        // prep connections and clean out these w/o assigned slots, as we might have established connections to unwanted hosts
+        {
+            let mut nodes_to_delete = Vec::new();
+            let connections_container = inner.conn_lock.read().await;
+
+            connections_container
+                .slot_map
+                .addresses_for_all_nodes()
+                .iter()
+                .for_each(|addr| {
+                    all_nodes_with_slots.insert(String::from(*addr));
+                });
+
+            connections_container
+                .all_node_connections()
+                .for_each(|(addr, con)| {
+                    if all_nodes_with_slots.contains(&addr) {
+                        all_valid_conns.insert(addr.clone(), con.clone());
+                    } else {
+                        nodes_to_delete.push(addr.clone());
+                    }
+                });
+
+            for addr in &nodes_to_delete {
+                connections_container.remove_node(addr);
+            }
+        }
+
+        // identify nodes with closed connection
+        let mut addrs_to_refresh = Vec::new();
+        for (addr, con_fut) in &all_valid_conns {
+            let con = con_fut.clone().await;
+            if con.is_closed() {
+                addrs_to_refresh.push(addr.clone());
+            }
+        }
+
+        // identify missing nodes
+        addrs_to_refresh.extend(
+            all_nodes_with_slots
+                .iter()
+                .filter(|addr| !all_valid_conns.contains_key(*addr))
+                .cloned(),
+        );
+
+        if !addrs_to_refresh.is_empty() {
+            // dont try existing nodes since we know a. it does not exist. b. exist but its connection is closed
+            Self::refresh_connections(
+                inner.clone(),
+                addrs_to_refresh,
+                RefreshConnectionType::AllConnections,
+                false,
+            )
+            .await;
+        }
+    }
+
     async fn refresh_connections(
         inner: Arc<InnerCore<C>>,
         addresses: Vec<String>,
         conn_type: RefreshConnectionType,
+        try_existing_node: bool,
     ) {
         info!("Started refreshing connections to {:?}", addresses);
         let connections_container = inner.conn_lock.read().await;
         let cluster_params = &inner.cluster_params;
         let subscriptions_by_address = &inner.subscriptions_by_address;
         let push_sender = &inner.push_sender;
+        let disconnect_notifier = &inner.disconnect_notifier;
 
         stream::iter(addresses.into_iter())
             .fold(
                 &*connections_container,
                 |connections_container, address| async move {
-                    let node_option = connections_container.remove_node(&address);
+                    let node_option = if try_existing_node {
+                        connections_container.remove_node(&address)
+                    } else {
+                        Option::None
+                    };
 
                     // override subscriptions for this connection
                     let mut cluster_params = cluster_params.clone();
@@ -1173,6 +1316,7 @@ where
                         &cluster_params,
                         conn_type,
                         push_sender.clone(),
+                        disconnect_notifier.clone(),
                     )
                     .await;
                     match node {
@@ -1394,6 +1538,20 @@ where
         }
     }
 
+    async fn connections_validation_task(inner: Arc<InnerCore<C>>, interval_duration: Duration) {
+        loop {
+            #[cfg(feature = "tokio-comp")]
+            let _ = timeout(interval_duration, async {
+                inner.tokio_notify.notified().await;
+            })
+            .await;
+            #[cfg(not(feature = "tokio-comp"))]
+            let _ = boxed_sleep(interval_duration).await;
+
+            Self::validate_all_user_connections(inner.clone()).await;
+        }
+    }
+
     async fn refresh_pubsub_subscriptions(inner: Arc<InnerCore<C>>) {
         if inner.cluster_params.protocol != crate::types::ProtocolVersion::RESP3 {
             return;
@@ -1471,17 +1629,12 @@ where
         drop(subs_by_address_guard);
 
         if !addrs_to_refresh.is_empty() {
-            let conns_read_guard = inner.conn_lock.read().await;
-            // have to remove or otherwise the refresh_connection wont trigger node recreation
-            for addr_to_refresh in addrs_to_refresh.iter() {
-                conns_read_guard.remove_node(addr_to_refresh);
-            }
-            drop(conns_read_guard);
             // immediately trigger connection reestablishment
             Self::refresh_connections(
                 inner.clone(),
                 addrs_to_refresh.into_iter().collect(),
                 RefreshConnectionType::AllConnections,
+                false,
             )
             .await;
         }
@@ -1517,6 +1670,7 @@ where
                 inner,
                 failed_connections,
                 RefreshConnectionType::OnlyManagementConnection,
+                true,
             )
             .await;
         }
@@ -1616,6 +1770,7 @@ where
                         &cluster_params,
                         RefreshConnectionType::AllConnections,
                         inner.push_sender.clone(),
+                        inner.disconnect_notifier.clone(),
                     )
                     .await;
                     if let Ok(node) = node {
@@ -1911,6 +2066,7 @@ where
                     RefreshConnectionType::AllConnections,
                     None,
                     core.push_sender.clone(),
+                    core.disconnect_notifier.clone(),
                 )
                 .await
                 .get_node()
@@ -2221,6 +2377,7 @@ where
                             self.inner.clone(),
                             addresses,
                             RefreshConnectionType::OnlyUserConnection,
+                            true,
                         ),
                     )));
                 }
@@ -2329,7 +2486,12 @@ where
     fn get_db(&self) -> i64 {
         0
     }
+
+    fn is_closed(&self) -> bool {
+        false
+    }
 }
+
 /// Implements the process of connecting to a Redis server
 /// and obtaining a connection handle.
 pub trait Connect: Sized {
@@ -2342,6 +2504,7 @@ pub trait Connect: Sized {
         connection_timeout: Duration,
         socket_addr: Option<SocketAddr>,
         push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
+        disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
     ) -> RedisFuture<'a, (Self, Option<IpAddr>)>
     where
         T: IntoConnectionInfo + Send + 'a;
@@ -2354,6 +2517,7 @@ impl Connect for MultiplexedConnection {
         connection_timeout: Duration,
         socket_addr: Option<SocketAddr>,
         push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
+        disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
     ) -> RedisFuture<'a, (MultiplexedConnection, Option<IpAddr>)>
     where
         T: IntoConnectionInfo + Send + 'a,
@@ -2371,6 +2535,7 @@ impl Connect for MultiplexedConnection {
                             response_timeout,
                             socket_addr,
                             push_sender,
+                            disconnect_notifier,
                         ),
                     )
                     .await?
@@ -2382,6 +2547,7 @@ impl Connect for MultiplexedConnection {
                             response_timeout,
                             socket_addr,
                             push_sender,
+                            disconnect_notifier,
                         ))
                         .await?
                 }

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -42,6 +42,8 @@ struct BuilderParams {
     #[cfg(feature = "cluster-async")]
     topology_checks_interval: Option<Duration>,
     #[cfg(feature = "cluster-async")]
+    connections_validation_interval: Option<Duration>,
+    #[cfg(feature = "cluster-async")]
     slots_refresh_rate_limit: SlotsRefreshRateLimit,
     client_name: Option<String>,
     response_timeout: Option<Duration>,
@@ -138,6 +140,8 @@ pub struct ClusterParams {
     pub(crate) topology_checks_interval: Option<Duration>,
     #[cfg(feature = "cluster-async")]
     pub(crate) slots_refresh_rate_limit: SlotsRefreshRateLimit,
+    #[cfg(feature = "cluster-async")]
+    pub(crate) connections_validation_interval: Option<Duration>,
     pub(crate) tls_params: Option<TlsConnParams>,
     pub(crate) client_name: Option<String>,
     pub(crate) connection_timeout: Duration,
@@ -169,6 +173,8 @@ impl ClusterParams {
             topology_checks_interval: value.topology_checks_interval,
             #[cfg(feature = "cluster-async")]
             slots_refresh_rate_limit: value.slots_refresh_rate_limit,
+            #[cfg(feature = "cluster-async")]
+            connections_validation_interval: value.connections_validation_interval,
             tls_params,
             client_name: value.client_name,
             response_timeout: value.response_timeout.unwrap_or(Duration::MAX),
@@ -390,6 +396,16 @@ impl ClusterClientBuilder {
     #[cfg(feature = "cluster-async")]
     pub fn periodic_topology_checks(mut self, interval: Duration) -> ClusterClientBuilder {
         self.builder_params.topology_checks_interval = Some(interval);
+        self
+    }
+
+    /// Enables periodic connections checks for this client.
+    /// If enabled, the conenctions to the cluster nodes will be validated periodicatly, per configured interval.
+    /// In addition, for tokio runtime, passive disconnections could be detected instantly,
+    /// triggering reestablishemnt, w/o waiting for the next periodic check.
+    #[cfg(feature = "cluster-async")]
+    pub fn periodic_connections_checks(mut self, interval: Duration) -> ClusterClientBuilder {
+        self.builder_params.connections_validation_interval = Some(interval);
         self
     }
 

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -364,6 +364,7 @@ assert_eq!(result, Ok(("foo".to_string(), b"bar".to_vec())));
 
 // public api
 pub use crate::client::Client;
+pub use crate::client::GlideConnectionOptions;
 pub use crate::cmd::{cmd, pack_command, pipe, Arg, Cmd, Iter};
 pub use crate::commands::{
     Commands, ControlFlow, Direction, LposOptions, PubSubCommands, SetOptions,

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -301,7 +301,7 @@ fn find_valid_master(
 #[cfg(feature = "aio")]
 async fn async_check_role(connection_info: &ConnectionInfo, target_role: &str) -> bool {
     if let Ok(client) = Client::open(connection_info.clone()) {
-        if let Ok(mut conn) = client.get_multiplexed_async_connection(None).await {
+        if let Ok(mut conn) = client.get_multiplexed_async_connection(None, None).await {
             let result: RedisResult<Vec<Value>> = crate::cmd("ROLE").query_async(&mut conn).await;
             return check_role_result(&result, target_role);
         }
@@ -366,7 +366,7 @@ async fn async_reconnect(
 ) -> RedisResult<()> {
     let sentinel_client = Client::open(connection_info.clone())?;
     let new_connection = sentinel_client
-        .get_multiplexed_async_connection(None)
+        .get_multiplexed_async_connection(None, None)
         .await?;
     connection.replace(new_connection);
     Ok(())
@@ -768,6 +768,6 @@ impl SentinelClient {
     #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
     pub async fn get_async_connection(&mut self) -> RedisResult<AsyncConnection> {
         let client = self.async_get_client().await?;
-        client.get_multiplexed_async_connection(None).await
+        client.get_multiplexed_async_connection(None, None).await
     }
 }

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -112,8 +112,8 @@ use rand::Rng;
 use crate::aio::MultiplexedConnection as AsyncConnection;
 
 use crate::{
-    connection::ConnectionInfo, types::RedisResult, Client, Cmd, Connection, ErrorKind,
-    FromRedisValue, IntoConnectionInfo, RedisConnectionInfo, TlsMode, Value,
+    client::GlideConnectionOptions, connection::ConnectionInfo, types::RedisResult, Client, Cmd,
+    Connection, ErrorKind, FromRedisValue, IntoConnectionInfo, RedisConnectionInfo, TlsMode, Value,
 };
 
 /// The Sentinel type, serves as a special purpose client which builds other clients on
@@ -301,7 +301,10 @@ fn find_valid_master(
 #[cfg(feature = "aio")]
 async fn async_check_role(connection_info: &ConnectionInfo, target_role: &str) -> bool {
     if let Ok(client) = Client::open(connection_info.clone()) {
-        if let Ok(mut conn) = client.get_multiplexed_async_connection(None, None).await {
+        if let Ok(mut conn) = client
+            .get_multiplexed_async_connection(GlideConnectionOptions::default())
+            .await
+        {
             let result: RedisResult<Vec<Value>> = crate::cmd("ROLE").query_async(&mut conn).await;
             return check_role_result(&result, target_role);
         }
@@ -366,7 +369,7 @@ async fn async_reconnect(
 ) -> RedisResult<()> {
     let sentinel_client = Client::open(connection_info.clone())?;
     let new_connection = sentinel_client
-        .get_multiplexed_async_connection(None, None)
+        .get_multiplexed_async_connection(GlideConnectionOptions::default())
         .await?;
     connection.replace(new_connection);
     Ok(())
@@ -768,6 +771,8 @@ impl SentinelClient {
     #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
     pub async fn get_async_connection(&mut self) -> RedisResult<AsyncConnection> {
         let client = self.async_get_client().await?;
-        client.get_multiplexed_async_connection(None, None).await
+        client
+            .get_multiplexed_async_connection(GlideConnectionOptions::default())
+            .await
     }
 }

--- a/redis/tests/support/mock_cluster.rs
+++ b/redis/tests/support/mock_cluster.rs
@@ -1,6 +1,6 @@
 use redis::{
     cluster::{self, ClusterClient, ClusterClientBuilder},
-    ErrorKind, FromRedisValue, PushInfo, RedisError,
+    ErrorKind, FromRedisValue, GlideConnectionOptions, RedisError,
 };
 
 use std::{
@@ -18,8 +18,6 @@ use {
     redis::{IntoConnectionInfo, RedisResult, Value},
 };
 
-use tokio::sync::mpsc;
-
 #[cfg(feature = "cluster-async")]
 use redis::{aio, cluster_async, RedisFuture};
 
@@ -28,9 +26,6 @@ use futures::future;
 
 #[cfg(feature = "cluster-async")]
 use tokio::runtime::Runtime;
-
-#[cfg(feature = "aio")]
-use redis::aio::DisconnectNotifier;
 
 type Handler = Arc<dyn Fn(&[u8], u16) -> Result<(), RedisResult<Value>> + Send + Sync>;
 
@@ -137,8 +132,7 @@ impl cluster_async::Connect for MockConnection {
         _response_timeout: Duration,
         _connection_timeout: Duration,
         _socket_addr: Option<SocketAddr>,
-        _push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
-        _disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
+        _glide_connection_options: GlideConnectionOptions,
     ) -> RedisFuture<'a, (Self, Option<IpAddr>)>
     where
         T: IntoConnectionInfo + Send + 'a,

--- a/redis/tests/support/mock_cluster.rs
+++ b/redis/tests/support/mock_cluster.rs
@@ -29,6 +29,9 @@ use futures::future;
 #[cfg(feature = "cluster-async")]
 use tokio::runtime::Runtime;
 
+#[cfg(feature = "aio")]
+use redis::aio::DisconnectNotifier;
+
 type Handler = Arc<dyn Fn(&[u8], u16) -> Result<(), RedisResult<Value>> + Send + Sync>;
 
 pub struct MockConnectionBehavior {
@@ -135,6 +138,7 @@ impl cluster_async::Connect for MockConnection {
         _connection_timeout: Duration,
         _socket_addr: Option<SocketAddr>,
         _push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
+        _disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
     ) -> RedisFuture<'a, (Self, Option<IpAddr>)>
     where
         T: IntoConnectionInfo + Send + 'a,
@@ -368,6 +372,10 @@ impl aio::ConnectionLike for MockConnection {
 
     fn get_db(&self) -> i64 {
         0
+    }
+
+    fn is_closed(&self) -> bool {
+        false
     }
 }
 

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -21,6 +21,9 @@ use redis::{ClientTlsConfig, TlsCertificates};
 use socket2::{Domain, Socket, Type};
 use tempfile::TempDir;
 
+#[cfg(feature = "aio")]
+use redis::GlideConnectionOptions;
+
 pub fn use_protocol() -> ProtocolVersion {
     if env::var("PROTOCOL").unwrap_or_default() == "RESP3" {
         ProtocolVersion::RESP3
@@ -502,7 +505,7 @@ impl TestContext {
     #[cfg(feature = "aio")]
     pub async fn async_connection(&self) -> redis::RedisResult<redis::aio::MultiplexedConnection> {
         self.client
-            .get_multiplexed_async_connection(None, None)
+            .get_multiplexed_async_connection(GlideConnectionOptions::default())
             .await
     }
 
@@ -516,7 +519,7 @@ impl TestContext {
         &self,
     ) -> redis::RedisResult<redis::aio::MultiplexedConnection> {
         self.client
-            .get_multiplexed_async_std_connection(None, None)
+            .get_multiplexed_async_std_connection(GlideConnectionOptions::default())
             .await
     }
 
@@ -536,7 +539,7 @@ impl TestContext {
         &self,
     ) -> redis::RedisResult<redis::aio::MultiplexedConnection> {
         self.client
-            .get_multiplexed_tokio_connection(None, None)
+            .get_multiplexed_tokio_connection(GlideConnectionOptions::default())
             .await
     }
 
@@ -545,7 +548,7 @@ impl TestContext {
         &self,
     ) -> redis::RedisResult<redis::aio::MultiplexedConnection> {
         self.client
-            .get_multiplexed_async_std_connection(None, None)
+            .get_multiplexed_async_std_connection(GlideConnectionOptions::default())
             .await
     }
 

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -501,7 +501,9 @@ impl TestContext {
 
     #[cfg(feature = "aio")]
     pub async fn async_connection(&self) -> redis::RedisResult<redis::aio::MultiplexedConnection> {
-        self.client.get_multiplexed_async_connection(None).await
+        self.client
+            .get_multiplexed_async_connection(None, None)
+            .await
     }
 
     #[cfg(feature = "aio")]
@@ -513,7 +515,9 @@ impl TestContext {
     pub async fn async_connection_async_std(
         &self,
     ) -> redis::RedisResult<redis::aio::MultiplexedConnection> {
-        self.client.get_multiplexed_async_std_connection(None).await
+        self.client
+            .get_multiplexed_async_std_connection(None, None)
+            .await
     }
 
     pub fn stop_server(&mut self) {
@@ -531,14 +535,18 @@ impl TestContext {
     pub async fn multiplexed_async_connection_tokio(
         &self,
     ) -> redis::RedisResult<redis::aio::MultiplexedConnection> {
-        self.client.get_multiplexed_tokio_connection(None).await
+        self.client
+            .get_multiplexed_tokio_connection(None, None)
+            .await
     }
 
     #[cfg(feature = "async-std-comp")]
     pub async fn multiplexed_async_connection_async_std(
         &self,
     ) -> redis::RedisResult<redis::aio::MultiplexedConnection> {
-        self.client.get_multiplexed_async_std_connection(None).await
+        self.client
+            .get_multiplexed_async_std_connection(None, None)
+            .await
     }
 
     pub fn get_version(&self) -> Version {

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -9,7 +9,8 @@ mod basic_async {
     use futures::{prelude::*, StreamExt};
     use redis::{
         aio::{ConnectionLike, MultiplexedConnection},
-        cmd, pipe, AsyncCommands, ErrorKind, PushInfo, PushKind, RedisResult, Value,
+        cmd, pipe, AsyncCommands, ErrorKind, GlideConnectionOptions, PushInfo, PushKind,
+        RedisResult, Value,
     };
     use tokio::sync::mpsc::error::TryRecvError;
 
@@ -100,7 +101,7 @@ mod basic_async {
     fn dont_panic_on_closed_multiplexed_connection() {
         let ctx = TestContext::new();
         let client = ctx.client.clone();
-        let connect = client.get_multiplexed_async_connection(None, None);
+        let connect = client.get_multiplexed_async_connection(GlideConnectionOptions::default());
         drop(ctx);
 
         block_on_all(async move {
@@ -584,7 +585,7 @@ mod basic_async {
         let client = redis::Client::open(coninfo).unwrap();
 
         let err = client
-            .get_multiplexed_tokio_connection(None, None)
+            .get_multiplexed_tokio_connection(GlideConnectionOptions::default())
             .await
             .err()
             .unwrap();
@@ -916,7 +917,10 @@ mod basic_async {
         let millisecond = std::time::Duration::from_millis(1);
         let mut retries = 0;
         loop {
-            match client.get_multiplexed_async_connection(None, None).await {
+            match client
+                .get_multiplexed_async_connection(GlideConnectionOptions::default())
+                .await
+            {
                 Err(err) => {
                     if err.is_connection_refusal() {
                         tokio::time::sleep(millisecond).await;
@@ -986,7 +990,8 @@ mod basic_async {
             let client =
                 build_single_client(ctx.server.connection_info(), &ctx.server.tls_paths, true)
                     .unwrap();
-            let connect = client.get_multiplexed_async_connection(None, None);
+            let connect =
+                client.get_multiplexed_async_connection(GlideConnectionOptions::default());
             block_on_all(connect.and_then(|mut con| async move {
                 redis::cmd("SET")
                     .arg("key1")
@@ -1007,7 +1012,8 @@ mod basic_async {
             let client =
                 build_single_client(ctx.server.connection_info(), &ctx.server.tls_paths, false)
                     .unwrap();
-            let connect = client.get_multiplexed_async_connection(None, None);
+            let connect =
+                client.get_multiplexed_async_connection(GlideConnectionOptions::default());
             let result = block_on_all(connect.and_then(|mut con| async move {
                 redis::cmd("SET")
                     .arg("key1")

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -100,7 +100,7 @@ mod basic_async {
     fn dont_panic_on_closed_multiplexed_connection() {
         let ctx = TestContext::new();
         let client = ctx.client.clone();
-        let connect = client.get_multiplexed_async_connection(None);
+        let connect = client.get_multiplexed_async_connection(None, None);
         drop(ctx);
 
         block_on_all(async move {
@@ -584,7 +584,7 @@ mod basic_async {
         let client = redis::Client::open(coninfo).unwrap();
 
         let err = client
-            .get_multiplexed_tokio_connection(None)
+            .get_multiplexed_tokio_connection(None, None)
             .await
             .err()
             .unwrap();
@@ -916,7 +916,7 @@ mod basic_async {
         let millisecond = std::time::Duration::from_millis(1);
         let mut retries = 0;
         loop {
-            match client.get_multiplexed_async_connection(None).await {
+            match client.get_multiplexed_async_connection(None, None).await {
                 Err(err) => {
                     if err.is_connection_refusal() {
                         tokio::time::sleep(millisecond).await;
@@ -986,7 +986,7 @@ mod basic_async {
             let client =
                 build_single_client(ctx.server.connection_info(), &ctx.server.tls_paths, true)
                     .unwrap();
-            let connect = client.get_multiplexed_async_connection(None);
+            let connect = client.get_multiplexed_async_connection(None, None);
             block_on_all(connect.and_then(|mut con| async move {
                 redis::cmd("SET")
                     .arg("key1")
@@ -1007,7 +1007,7 @@ mod basic_async {
             let client =
                 build_single_client(ctx.server.connection_info(), &ctx.server.tls_paths, false)
                     .unwrap();
-            let connect = client.get_multiplexed_async_connection(None);
+            let connect = client.get_multiplexed_async_connection(None, None);
             let result = block_on_all(connect.and_then(|mut con| async move {
                 redis::cmd("SET")
                     .arg("key1")

--- a/redis/tests/test_async_async_std.rs
+++ b/redis/tests/test_async_async_std.rs
@@ -3,7 +3,7 @@ use futures::prelude::*;
 
 use crate::support::*;
 
-use redis::{aio::MultiplexedConnection, RedisResult};
+use redis::{aio::MultiplexedConnection, GlideConnectionOptions, RedisResult};
 
 mod support;
 
@@ -61,7 +61,7 @@ fn test_args_async_std() {
 fn dont_panic_on_closed_multiplexed_connection() {
     let ctx = TestContext::new();
     let client = ctx.client.clone();
-    let connect = client.get_multiplexed_async_std_connection(None, None);
+    let connect = client.get_multiplexed_async_std_connection(GlideConnectionOptions::default());
     drop(ctx);
 
     block_on_all_using_async_std(async move {

--- a/redis/tests/test_async_async_std.rs
+++ b/redis/tests/test_async_async_std.rs
@@ -61,7 +61,7 @@ fn test_args_async_std() {
 fn dont_panic_on_closed_multiplexed_connection() {
     let ctx = TestContext::new();
     let client = ctx.client.clone();
-    let connect = client.get_multiplexed_async_std_connection(None);
+    let connect = client.get_multiplexed_async_std_connection(None, None);
     drop(ctx);
 
     block_on_all_using_async_std(async move {

--- a/redis/tests/test_async_cluster_connections_logic.rs
+++ b/redis/tests/test_async_cluster_connections_logic.rs
@@ -73,6 +73,7 @@ mod test_connect_and_check {
             RefreshConnectionType::AllConnections,
             None,
             None,
+            None,
         )
         .await;
         let node = assert_full_success(result);
@@ -109,6 +110,7 @@ mod test_connect_and_check {
             RefreshConnectionType::AllConnections,
             None,
             None,
+            None,
         )
         .await;
         let (node, _) = assert_partial_result(result);
@@ -125,6 +127,7 @@ mod test_connect_and_check {
             params,
             None,
             RefreshConnectionType::AllConnections,
+            None,
             None,
             None,
         )
@@ -158,6 +161,7 @@ mod test_connect_and_check {
             ClusterParams::default(),
             None,
             RefreshConnectionType::AllConnections,
+            None,
             None,
             None,
         )
@@ -195,6 +199,7 @@ mod test_connect_and_check {
             ClusterParams::default(),
             None,
             RefreshConnectionType::AllConnections,
+            None,
             None,
             None,
         )
@@ -248,6 +253,7 @@ mod test_connect_and_check {
             RefreshConnectionType::OnlyManagementConnection,
             Some(node),
             None,
+            None,
         )
         .await;
         let node = assert_full_success(result);
@@ -294,6 +300,7 @@ mod test_connect_and_check {
             None,
             RefreshConnectionType::OnlyManagementConnection,
             Some(node),
+            None,
             None,
         )
         .await;
@@ -356,6 +363,7 @@ mod test_connect_and_check {
             None,
             RefreshConnectionType::OnlyUserConnection,
             Some(node),
+            None,
             None,
         )
         .await;

--- a/redis/tests/test_async_cluster_connections_logic.rs
+++ b/redis/tests/test_async_cluster_connections_logic.rs
@@ -5,7 +5,7 @@ mod support;
 use redis::{
     cluster_async::testing::{AsyncClusterNode, RefreshConnectionType},
     testing::ClusterParams,
-    ErrorKind,
+    ErrorKind, GlideConnectionOptions,
 };
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
@@ -72,8 +72,7 @@ mod test_connect_and_check {
             None,
             RefreshConnectionType::AllConnections,
             None,
-            None,
-            None,
+            GlideConnectionOptions::default(),
         )
         .await;
         let node = assert_full_success(result);
@@ -109,8 +108,7 @@ mod test_connect_and_check {
             None,
             RefreshConnectionType::AllConnections,
             None,
-            None,
-            None,
+            GlideConnectionOptions::default(),
         )
         .await;
         let (node, _) = assert_partial_result(result);
@@ -128,8 +126,7 @@ mod test_connect_and_check {
             None,
             RefreshConnectionType::AllConnections,
             None,
-            None,
-            None,
+            GlideConnectionOptions::default(),
         )
         .await;
         let (node, _) = assert_partial_result(result);
@@ -162,8 +159,7 @@ mod test_connect_and_check {
             None,
             RefreshConnectionType::AllConnections,
             None,
-            None,
-            None,
+            GlideConnectionOptions::default(),
         )
         .await;
         let node = assert_full_success(result);
@@ -200,8 +196,7 @@ mod test_connect_and_check {
             None,
             RefreshConnectionType::AllConnections,
             None,
-            None,
-            None,
+            GlideConnectionOptions::default(),
         )
         .await;
         let err = result.get_error().unwrap();
@@ -252,8 +247,7 @@ mod test_connect_and_check {
             None,
             RefreshConnectionType::OnlyManagementConnection,
             Some(node),
-            None,
-            None,
+            GlideConnectionOptions::default(),
         )
         .await;
         let node = assert_full_success(result);
@@ -300,8 +294,7 @@ mod test_connect_and_check {
             None,
             RefreshConnectionType::OnlyManagementConnection,
             Some(node),
-            None,
-            None,
+            GlideConnectionOptions::default(),
         )
         .await;
         let (node, _) = assert_partial_result(result);
@@ -363,8 +356,7 @@ mod test_connect_and_check {
             None,
             RefreshConnectionType::OnlyUserConnection,
             Some(node),
-            None,
-            None,
+            GlideConnectionOptions::default(),
         )
         .await;
         let node = assert_full_success(result);

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -21,7 +21,7 @@ mod cluster_async {
     use std::ops::Add;
 
     use redis::{
-        aio::{ConnectionLike, MultiplexedConnection},
+        aio::{ConnectionLike, DisconnectNotifier, MultiplexedConnection},
         cluster::ClusterClient,
         cluster_async::{testing::MANAGEMENT_CONN_NAME, ClusterConnection, Connect},
         cluster_routing::{
@@ -42,6 +42,60 @@ mod cluster_async {
             std::io::ErrorKind::BrokenPipe,
             "mock-io-error",
         ))
+    }
+
+    fn validate_subscriptions(
+        pubsub_subs: &PubSubSubscriptionInfo,
+        notifications_rx: &mut mpsc::UnboundedReceiver<PushInfo>,
+        allow_disconnects: bool,
+    ) {
+        let mut subscribe_cnt =
+            if let Some(exact_subs) = pubsub_subs.get(&PubSubSubscriptionKind::Exact) {
+                exact_subs.len()
+            } else {
+                0
+            };
+
+        let mut psubscribe_cnt =
+            if let Some(pattern_subs) = pubsub_subs.get(&PubSubSubscriptionKind::Pattern) {
+                pattern_subs.len()
+            } else {
+                0
+            };
+
+        let mut ssubscribe_cnt =
+            if let Some(sharded_subs) = pubsub_subs.get(&PubSubSubscriptionKind::Sharded) {
+                sharded_subs.len()
+            } else {
+                0
+            };
+
+        for _ in 0..(subscribe_cnt + psubscribe_cnt + ssubscribe_cnt) {
+            let result = notifications_rx.try_recv();
+            assert!(result.is_ok());
+            let PushInfo { kind, data: _ } = result.unwrap();
+            assert!(
+                kind == PushKind::Subscribe
+                    || kind == PushKind::PSubscribe
+                    || kind == PushKind::SSubscribe
+                    || if allow_disconnects {
+                        kind == PushKind::Disconnection
+                    } else {
+                        false
+                    }
+            );
+            if kind == PushKind::Subscribe {
+                subscribe_cnt -= 1;
+            } else if kind == PushKind::PSubscribe {
+                psubscribe_cnt -= 1;
+            } else if kind == PushKind::SSubscribe {
+                ssubscribe_cnt -= 1;
+            }
+        }
+
+        assert!(subscribe_cnt == 0);
+        assert!(psubscribe_cnt == 0);
+        assert!(ssubscribe_cnt == 0);
     }
 
     #[test]
@@ -382,7 +436,7 @@ mod cluster_async {
                         .unwrap_or_else(|e| panic!("Failed to connect to '{addr}': {e}"));
 
                     let mut conn = client
-                        .get_multiplexed_async_connection(None)
+                        .get_multiplexed_async_connection(None, None)
                         .await
                         .unwrap_or_else(|e| panic!("Failed to get connection: {e}"));
 
@@ -482,6 +536,7 @@ mod cluster_async {
             connection_timeout: std::time::Duration,
             socket_addr: Option<SocketAddr>,
             push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
+            disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
         ) -> RedisFuture<'a, (Self, Option<IpAddr>)>
         where
             T: IntoConnectionInfo + Send + 'a,
@@ -493,6 +548,7 @@ mod cluster_async {
                     connection_timeout,
                     socket_addr,
                     push_sender,
+                    disconnect_notifier,
                 )
                 .await?;
                 Ok((ErrorConnection { inner }, None))
@@ -520,6 +576,10 @@ mod cluster_async {
 
         fn get_db(&self) -> i64 {
             self.inner.get_db()
+        }
+
+        fn is_closed(&self) -> bool {
+            true
         }
     }
 
@@ -2683,546 +2743,522 @@ mod cluster_async {
     }
 
     #[test]
-    fn test_async_cluster_restore_resp3_pubsub_state_after_complete_server_disconnect() {
-        // let cluster = TestClusterContext::new_with_cluster_client_builder(
-        //     3,
-        //     0,
-        //     |builder| builder.retries(3).use_protocol(ProtocolVersion::RESP3),
-        //     //|builder| builder.retries(3),
-        //     false,
-        // );
+    fn test_async_cluster_test_fast_reconnect() {
+        // Note the 3 seconds connection check to differentiate between notifications and periodic
+        let cluster = TestClusterContext::new_with_cluster_client_builder(
+            3,
+            0,
+            |builder| {
+                builder
+                    .retries(0)
+                    .periodic_connections_checks(Duration::from_secs(3))
+            },
+            false,
+        );
 
-        // block_on_all(async move {
-        //     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<PushInfo>();
-        //     let mut connection = cluster.async_connection(Some(tx.clone())).await;
-        //     // assuming the implementation of TestCluster assigns the slots monotonicaly incerasing with the nodes
-        //     let route_0 = redis::cluster_routing::Route::new(0, redis::cluster_routing::SlotAddr::Master);
-        //     let node_0_route = redis::cluster_routing::SingleNodeRoutingInfo::SpecificNode(route_0);
-        //     let route_2 = redis::cluster_routing::Route::new(16 * 1024 - 1, redis::cluster_routing::SlotAddr::Master);
-        //     let node_2_route = redis::cluster_routing::SingleNodeRoutingInfo::SpecificNode(route_2);
+        // For tokio-comp, do 3 consequtive disconnects and ensure reconnects succeeds in less than 100ms,
+        // which is more than enough for local connections even with TLS.
+        // More than 1 run is done to ensure it is the fast reconnect notification that trigger the reconnect
+        // and not the periodic interval.
+        // For other async implementation, only periodic connection check is available, hence,
+        // do 1 run sleeping for periodic connection check interval, allowing it to reestablish connections
+        block_on_all(async move {
+            let mut disconnecting_con = cluster.async_connection(None).await;
+            let mut monitoring_con = cluster.async_connection(None).await;
 
-        //     let result = connection
-        //     .route_command(&redis::Cmd::new().arg("SUBSCRIBE").arg("test_channel"), RoutingInfo::SingleNode(node_0_route.clone()))
-        //     //.route_command(&redis::Cmd::new().arg("SUBSCRIBE").arg("test_channel"), RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random))
-        //     .await;
+            #[cfg(feature = "tokio-comp")]
+            let tries = 0..3;
+            #[cfg(not(feature = "tokio-comp"))]
+            let tries = 0..1;
 
-        //     assert_eq!(
-        //         result,
-        //         Ok(Value::Push {
-        //             kind: PushKind::Subscribe,
-        //             data: vec![Value::BulkString("test_channel".into()), Value::Int(1)],
-        //         })
-        //     );
+            for _ in tries {
+                // get connection id
+                let mut cmd = redis::cmd("CLIENT");
+                cmd.arg("ID");
+                let res = disconnecting_con
+                    .route_command(
+                        &cmd,
+                        RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(Route::new(
+                            0,
+                            SlotAddr::Master,
+                        ))),
+                    )
+                    .await;
+                assert!(res.is_ok());
+                let res = res.unwrap();
+                let id = {
+                    match res {
+                        Value::Int(id) => id,
+                        _ => {
+                            panic!("Wrong return value for CLIENT ID command: {:?}", res);
+                        }
+                    }
+                };
 
-        //     // pull out all the subscribe notification, this push notification is due to the previous subscribe command
-        //     let result = rx.recv().await;
-        //     assert!(result.is_some());
-        //     let PushInfo { kind, data } = result.unwrap();
-        //     assert_eq!(
-        //         (kind, data),
-        //         (
-        //             PushKind::Subscribe,
-        //             vec![
-        //                 Value::BulkString("test_channel".as_bytes().to_vec()),
-        //                 Value::Int(1),
-        //             ]
-        //         )
-        //     );
+                // ask server to kill the connection
+                let mut cmd = redis::cmd("CLIENT");
+                cmd.arg("KILL").arg("ID").arg(id).arg("SKIPME").arg("NO");
+                let res = disconnecting_con
+                    .route_command(
+                        &cmd,
+                        RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(Route::new(
+                            0,
+                            SlotAddr::Master,
+                        ))),
+                    )
+                    .await;
+                // assert server has closed connection
+                assert_eq!(res, Ok(Value::Int(1)));
 
-        //     // ensure subscription, routing on the same node, expected return Int(1)
-        //     let result = connection
-        //     .route_command(&redis::Cmd::new().arg("PUBLISH").arg("test_channel").arg("test_message_from_node_0"), RoutingInfo::SingleNode(node_0_route.clone()))
-        //     .await;
-        //     assert_eq!(
-        //         result,
-        //         Ok(Value::Int(1))
-        //     );
+                #[cfg(feature = "tokio-comp")]
+                // ensure reconnect happened in less than 100ms
+                sleep(futures_time::time::Duration::from_millis(100)).await;
 
-        //     // ensure subscription, routing on different node, expected return Int(0)
-        //     let result = connection
-        //     .route_command(&redis::Cmd::new().arg("PUBLISH").arg("test_channel").arg("test_message_from_node_2"), RoutingInfo::SingleNode(node_2_route.clone()))
-        //     .await;
-        //     assert_eq!(
-        //         result,
-        //         Ok(Value::Int(0))
-        //     );
+                #[cfg(not(feature = "tokio-comp"))]
+                // no fast notification is available, wait for 1 periodic check + overhead
+                sleep(futures_time::time::Duration::from_secs(3 + 1)).await;
 
-        //     for i in vec![0, 2] {
-        //         let result = rx.recv().await;
-        //         assert!(result.is_some());
-        //         let PushInfo { kind, data } = result.unwrap();
-        //         println!("^^^^^^^^^ '{:?} -> {:?}'", kind, data);
-        //         assert_eq!(
-        //             (kind, data),
-        //             (
-        //                 PushKind::Message,
-        //                 vec![
-        //                     Value::BulkString("test_channel".into()),
-        //                     Value::BulkString(format!("test_message_from_node_{}", i).into()),
-        //                 ]
-        //             )
-        //         );
-        //     }
-
-        //     // drop and recreate cluster and connections
-        //     drop(cluster);
-        //     println!("*********** DROPPED **********");
-
-        //     let cluster = TestClusterContext::new_with_cluster_client_builder(
-        //         3,
-        //         0,
-        //         |builder| builder.retries(3).use_protocol(ProtocolVersion::RESP3),
-        //         //|builder| builder.retries(3),
-        //         false,
-        //     );
-
-        //     let result = connection
-        //     .route_command(&redis::Cmd::new().arg("PUBLISH").arg("test_channel").arg("test_message_from_node_0"), RoutingInfo::SingleNode(node_0_route.clone()))
-        //     .await;
-        //     assert_eq!(
-        //         result,
-        //         Ok(Value::Int(1))
-        //     );
-
-        //     //sleep(futures_time::time::Duration::from_secs(15)).await;
-        //     //return Ok(());
-
-        //     let cluster = TestClusterContext::new_with_cluster_client_builder(
-        //         3,
-        //         0,
-        //         |builder| builder.retries(3).use_protocol(ProtocolVersion::RESP3),
-        //         //|builder| builder.retries(3),
-        //         false,
-        //     );
-
-        //     // ensure subscription state restore
-        //     let result = connection
-        //     .route_command(&redis::Cmd::new().arg("PUBLISH").arg("test_channel").arg("test_message_from_node_0"), RoutingInfo::SingleNode(node_0_route.clone()))
-        //     .await;
-        //     assert_eq!(
-        //         result,
-        //         Ok(Value::Int(1))
-        //     );
-
-        //     // non-subscribed channel
-        //     let result = connection
-        //     .route_command(&redis::Cmd::new().arg("PUBLISH").arg("test_channel_1").arg("should_not_receive"), RoutingInfo::SingleNode(node_0_route.clone()))
-        //     .await;
-        //     assert_eq!(
-        //         result,
-        //         Ok(Value::Int(0))
-        //     );
-
-        //     // ensure subscription, routing on different node, expected return Int(0)
-        //     let result = connection
-        //     .route_command(&redis::Cmd::new().arg("PUBLISH").arg("test_channel").arg("test_message_from_node_2"), RoutingInfo::SingleNode(node_2_route.clone()))
-        //     .await;
-        //     assert_eq!(
-        //         result,
-        //         Ok(Value::Int(0))
-        //     );
-
-        //     // should produce an arbitrary number of 'disconnected' notifications - 1 for the intitial try after the drop and an unknown? amout during reconnecting procedure
-        //     // Notifications become available ONLY after we try to send the commands, since push manager does not register TCP disconnect on a idle socket
-        //     // Remove the any amount of 'disconnected' notifications
-        //     sleep(futures_time::time::Duration::from_secs(1)).await;
-        //     //let mut result = rx.recv().await;
-        //     let mut result = rx.try_recv();
-        //     assert!(result.is_ok());
-        //     //assert!(result.is_some());
-        //     loop {
-        //         let kind = result.clone().unwrap().kind;
-        //         if kind != PushKind::Disconnection && kind != PushKind::Subscribe {
-        //             break;
-        //         }
-        //         // result = rx.recv().await;
-        //         // assert!(result.is_some());
-        //         result = rx.try_recv();
-        //         assert!(result.is_ok());
-        //     }
-
-        //     // ensure messages test_message_from_node_0 and test_message_from_node_2
-        //     let mut msg_from_0 = false;
-        //     let mut msg_from_2 = false;
-        //     while !msg_from_0 && !msg_from_2 {
-        //         let mut result = rx.recv().await;
-        //         assert!(result.is_some());
-        //         let PushInfo { kind, data } = result.unwrap();
-
-        //         assert!(kind == PushKind::Disconnection || kind == PushKind::Subscribe || kind == PushKind::Message);
-        //         if kind == PushKind::Disconnection || kind == PushKind::Subscribe {
-        //             // ignore
-        //             continue;
-        //         }
-
-        //         if data == vec![
-        //             Value::BulkString("test_channel".into()),
-        //             Value::BulkString("test_message_from_node_0".into())] {
-        //             assert!(!msg_from_0);
-        //             msg_from_0 = true;
-        //         }
-        //         else if data == vec![
-        //             Value::BulkString("test_channel".into()),
-        //             Value::BulkString("test_message_from_node_2".into())] {
-        //             assert!(!msg_from_2);
-        //             msg_from_2 = true;
-        //         }
-        //         else {
-        //             assert!(false, "Unexpected message received");
-        //         }
-        //     }
-
-        //     // let mut msg_from_0 = false;
-        //     // let mut msg_from_2 = false;
-        //     // while !msg_from_2 {
-        //     //     let mut result = rx.recv().await;
-        //     //     assert!(result.is_some());
-        //     //     let PushInfo { kind, data } = result.unwrap();
-
-        //     //     assert!(kind == PushKind::Disconnection || kind == PushKind::Subscribe || kind == PushKind::Message);
-        //     //     if kind == PushKind::Disconnection || kind == PushKind::Subscribe {
-        //     //         // ignore
-        //     //         continue;
-        //     //     }
-
-        //     //     if data == vec![
-        //     //         Value::BulkString("test_channel".into()),
-        //     //         Value::BulkString("test_message_from_node_2".into())] {
-        //     //         assert!(!msg_from_2);
-        //     //         msg_from_2 = true;
-        //     //     }
-        //     //     else {
-        //     //         assert!(false, "Unexpected message received");
-        //     //     }
-        //     // }
-
-        //     Ok(())
-        // })
-        // .unwrap();
+                let mut cmd = redis::cmd("CLIENT");
+                cmd.arg("LIST").arg("TYPE").arg("NORMAL");
+                let res = monitoring_con
+                    .route_command(
+                        &cmd,
+                        RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(Route::new(
+                            0,
+                            SlotAddr::Master,
+                        ))),
+                    )
+                    .await;
+                assert!(res.is_ok());
+                let res = res.unwrap();
+                let client_list: String = {
+                    match res {
+                        // RESP2
+                        Value::BulkString(client_info) => {
+                            // ensure 4 connections - 2 for each client, its save to unwrap here
+                            String::from_utf8(client_info).unwrap()
+                        }
+                        // RESP3
+                        Value::VerbatimString { format: _, text } => text,
+                        _ => {
+                            panic!("Wrong return type for CLIENT LIST command: {:?}", res);
+                        }
+                    }
+                };
+                assert_eq!(client_list.chars().filter(|&x| x == '\n').count(), 4);
+            }
+            Ok(())
+        })
+        .unwrap();
     }
 
     #[test]
-    fn test_async_cluster_restore_resp3_pubsub_state_after_scale_in() {
+    fn test_async_cluster_restore_resp3_pubsub_state_passive_disconnect() {
+        let redis_ver = std::env::var("REDIS_VERSION").unwrap_or_default();
+        let use_sharded = redis_ver.starts_with("7.");
 
-        // let client_subscriptions = PubSubSubscriptionInfo::from(
-        //     [
-        //         (PubSubSubscriptionKind::Exact, HashSet::from(
-        //             [
-        //                 // test_channel_? is used as it maps to the last node in both 3 and 6 node config
-        //                 // (assuming slots allocation is monotonicaly increasing starting from node 0)
-        //                 PubSubChannelOrPattern::from(b"test_channel_?")
-        //             ])
-        //         )
-        //     ]
-        // );
+        let mut client_subscriptions = PubSubSubscriptionInfo::from([(
+            PubSubSubscriptionKind::Exact,
+            HashSet::from([PubSubChannelOrPattern::from("test_channel".as_bytes())]),
+        )]);
 
-        // let cluster = TestClusterContext::new_with_cluster_client_builder(
-        //     6,
-        //     0,
-        //     |builder| builder
-        //     .retries(3)
-        //     .use_protocol(ProtocolVersion::RESP3)
-        //     .pubsub_subscriptions(client_subscriptions.clone()),
-        //     false,
-        // );
+        if use_sharded {
+            client_subscriptions.insert(
+                PubSubSubscriptionKind::Sharded,
+                HashSet::from([PubSubChannelOrPattern::from("test_channel_?".as_bytes())]),
+            );
+        }
 
-        // block_on_all(async move {
-        //     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<PushInfo>();
-        //     let mut connection = cluster.async_connection(Some(tx.clone())).await;
+        // note topology change detection is not activated since no topology change is expected
+        let cluster = TestClusterContext::new_with_cluster_client_builder(
+            3,
+            0,
+            |builder| {
+                builder
+                    .retries(3)
+                    .use_protocol(ProtocolVersion::RESP3)
+                    .pubsub_subscriptions(client_subscriptions.clone())
+                    .periodic_connections_checks(Duration::from_secs(1))
+            },
+            false,
+        );
 
-        //     // short sleep to allow the server to push subscription notification
-        //     sleep(futures_time::time::Duration::from_secs(1)).await;
-        //     let result = rx.try_recv();
-        //     assert!(result.is_ok());
-        //     let PushInfo { kind, data } = result.unwrap();
-        //     assert_eq!(
-        //         (kind, data),
-        //         (
-        //             PushKind::Subscribe,
-        //             vec![
-        //                 Value::BulkString("test_channel_?".into()),
-        //                 Value::Int(1),
-        //             ]
-        //         )
-        //     );
+        block_on_all(async move {
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<PushInfo>();
+            let mut _listening_con = cluster.async_connection(Some(tx.clone())).await;
+            // Note, publishing connection has the same pubsub config
+            let mut publishing_con = cluster.async_connection(None).await;
 
-        //     let slot_14212 = get_slot(b"test_channel_?");
-        //     assert_eq!(slot_14212, 14212);
-        //     let slot_14212_route = redis::cluster_routing::Route::new(slot_14212, redis::cluster_routing::SlotAddr::Master);
-        //     let node_5_route = redis::cluster_routing::SingleNodeRoutingInfo::SpecificNode(slot_14212_route);
+            // short sleep to allow the server to push subscription notification
+            sleep(futures_time::time::Duration::from_secs(1)).await;
 
-        //     let result = connection
-        //     //.route_command(&redis::Cmd::new().arg("PUBLISH").arg("test_channel_?").arg("test_msg"), RoutingInfo::SingleNode(node_5_route.clone()))
-        //     .route_command(&redis::Cmd::new().arg("PING"), RoutingInfo::SingleNode(node_5_route.clone()))
-        //     .await;
-        //     // let slot_0_route = redis::cluster_routing::Route::new(0, redis::cluster_routing::SlotAddr::Master);
-        //     // let node_0_route = redis::cluster_routing::SingleNodeRoutingInfo::SpecificNode(slot_0_route);
+            // validate subscriptions
+            validate_subscriptions(&client_subscriptions, &mut rx, false);
 
-        //     let result = cmd("PUBLISH")
-        //     .arg("test_channel_?")
-        //     .arg("test_message")
-        //     .query_async(&mut connection)
-        //     .await;
-        //     assert_eq!(
-        //         result,
-        //         Ok(Value::Int(1))
-        //     );
+            // validate PUBLISH
+            let result = cmd("PUBLISH")
+                .arg("test_channel")
+                .arg("test_message")
+                .query_async(&mut publishing_con)
+                .await;
+            assert_eq!(
+                result,
+                Ok(Value::Int(2)) // 2 connections with the same pubsub config
+            );
 
-        //     sleep(futures_time::time::Duration::from_secs(1)).await;
-        //     let result = rx.try_recv();
-        //     assert!(result.is_ok());
-        //     let PushInfo { kind, data } = result.unwrap();
-        //     assert_eq!(
-        //         (kind, data),
-        //         (
-        //             PushKind::Message,
-        //             vec![
-        //                 Value::BulkString("test_channel_?".into()),
-        //                 Value::BulkString(format!("test_message").into()),
-        //             ]
-        //         )
-        //     );
+            sleep(futures_time::time::Duration::from_secs(1)).await;
+            let result = rx.try_recv();
+            assert!(result.is_ok());
+            let PushInfo { kind, data } = result.unwrap();
+            assert_eq!(
+                (kind, data),
+                (
+                    PushKind::Message,
+                    vec![
+                        Value::BulkString("test_channel".into()),
+                        Value::BulkString("test_message".into()),
+                    ]
+                )
+            );
 
-        //     // simulate scale in
-        //     drop(cluster);
-        //     println!("*********** DROPPED **********");
-        //     let cluster = TestClusterContext::new_with_cluster_client_builder(
-        //         3,
-        //         0,
-        //         |builder| builder
-        //         .retries(6)
-        //         .use_protocol(ProtocolVersion::RESP3)
-        //         .pubsub_subscriptions(client_subscriptions.clone()),
-        //         false,
-        //     );
+            if use_sharded {
+                // validate SPUBLISH
+                let result = cmd("SPUBLISH")
+                    .arg("test_channel_?")
+                    .arg("test_message")
+                    .query_async(&mut publishing_con)
+                    .await;
+                assert_eq!(
+                    result,
+                    Ok(Value::Int(2)) // 2 connections with the same pubsub config
+                );
 
-        //     sleep(futures_time::time::Duration::from_secs(3)).await;
+                sleep(futures_time::time::Duration::from_secs(1)).await;
+                let result = rx.try_recv();
+                assert!(result.is_ok());
+                let PushInfo { kind, data } = result.unwrap();
+                assert_eq!(
+                    (kind, data),
+                    (
+                        PushKind::SMessage,
+                        vec![
+                            Value::BulkString("test_channel_?".into()),
+                            Value::BulkString("test_message".into()),
+                        ]
+                    )
+                );
+            }
 
-        //     //ensure subscription notification due to resubscription
-        //     // let result = cmd("PUBLISH")
-        //     // .arg("test_channel_?")
-        //     // .arg("test_message")
-        //     // .query_async(&mut connection)
-        //     // .await;
-        //     let result = connection
-        //     //.route_command(&redis::Cmd::new().arg("PUBLISH").arg("test_channel_?").arg("test_msg"), RoutingInfo::SingleNode(node_5_route.clone()))
-        //     .route_command(&redis::Cmd::new().arg("PING"), RoutingInfo::SingleNode(node_5_route.clone()))
-        //     .await;
-        //     // assert_eq!(
-        //     //     result,
-        //     //     Ok(Value::Int(1))
-        //     // );
+            // simulate passive disconnect
+            drop(cluster);
 
-        //     let slot_14212 = get_slot(b"test_channel_?");
-        //     assert_eq!(slot_14212, 14212);
-        //     let slot_14212_route = redis::cluster_routing::Route::new(slot_14212, redis::cluster_routing::SlotAddr::Master);
-        //     let node_2_route = redis::cluster_routing::SingleNodeRoutingInfo::SpecificNode(slot_14212_route);
-        //     let result = connection
-        //     .route_command(&redis::Cmd::new().arg("PUBLISH").arg("test_channel_?").arg("test_message"), RoutingInfo::SingleNode(node_2_route.clone()))
-        //     .await;
-        //     assert_eq!(
-        //         result,
-        //         Ok(Value::Int(1))
-        //     );
+            // recreate the cluster, the assumtion is that the cluster is built with exactly the same params (ports, slots map...)
+            let _cluster =
+                TestClusterContext::new_with_cluster_client_builder(3, 0, |builder| builder, false);
 
-        //     sleep(futures_time::time::Duration::from_secs(1)).await;
-        //     let result = rx.try_recv();
-        //     assert!(result.is_ok());
-        //     let PushInfo { kind, data } = result.unwrap();
-        //     assert_eq!(
-        //         (kind, data),
-        //         (
-        //             PushKind::Subscribe,
-        //             vec![
-        //                 Value::BulkString("test_channel_?".into()),
-        //                 Value::Int(1),
-        //             ]
-        //         )
-        //     );
+            // sleep for 1 periodic_connections_checks + overhead
+            sleep(futures_time::time::Duration::from_secs(1 + 1)).await;
 
-        //     let result = rx.try_recv();
-        //     assert!(result.is_ok());
-        //     let PushInfo { kind, data } = result.unwrap();
-        //     assert_eq!(
-        //         (kind, data),
-        //         (
-        //             PushKind::Disconnection,
-        //             vec![],
-        //         )
-        //     );
+            // new subscription notifications due to resubscriptions
+            validate_subscriptions(&client_subscriptions, &mut rx, true);
 
-        //     return Ok(());
+            // validate PUBLISH
+            let result = cmd("PUBLISH")
+                .arg("test_channel")
+                .arg("test_message")
+                .query_async(&mut publishing_con)
+                .await;
+            assert_eq!(
+                result,
+                Ok(Value::Int(2)) // 2 connections with the same pubsub config
+            );
 
-        //     // Subscribe on the slot 14212, this slot will reside on the last node in both 3 and 6 nodes cluster,
-        //     // When the cluster is recreated with 3 nodes, this slot will reside on different network address.
-        //     // Assuming the implementation of TestCluster assigns the slots monotonicaly incerasing with the nodes
-        //     let slot_14212 = get_slot(b"test_channel_?");
-        //     assert_eq!(slot_14212, 14212);
-        //     let slot_14212_route = redis::cluster_routing::Route::new(slot_14212, redis::cluster_routing::SlotAddr::Master);
-        //     let node_5_route = redis::cluster_routing::SingleNodeRoutingInfo::SpecificNode(slot_14212_route);
+            sleep(futures_time::time::Duration::from_secs(1)).await;
+            let result = rx.try_recv();
+            assert!(result.is_ok());
+            let PushInfo { kind, data } = result.unwrap();
+            assert_eq!(
+                (kind, data),
+                (
+                    PushKind::Message,
+                    vec![
+                        Value::BulkString("test_channel".into()),
+                        Value::BulkString("test_message".into()),
+                    ]
+                )
+            );
 
-        //     let slot_0_route = redis::cluster_routing::Route::new(0, redis::cluster_routing::SlotAddr::Master);
-        //     let node_0_route = redis::cluster_routing::SingleNodeRoutingInfo::SpecificNode(slot_0_route);
+            if use_sharded {
+                // validate SPUBLISH
+                let result = cmd("SPUBLISH")
+                    .arg("test_channel_?")
+                    .arg("test_message")
+                    .query_async(&mut publishing_con)
+                    .await;
+                assert_eq!(
+                    result,
+                    Ok(Value::Int(2)) // 2 connections with the same pubsub config
+                );
 
-        //     let result = connection
-        //     .route_command(&redis::Cmd::new().arg("SUBSCRIBE").arg("test_channel_?"), RoutingInfo::SingleNode(node_5_route.clone()))
-        //     //.route_command(&redis::Cmd::new().arg("SUBSCRIBE").arg("test_channel"), RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random))
-        //     .await;
+                sleep(futures_time::time::Duration::from_secs(1)).await;
+                let result = rx.try_recv();
+                assert!(result.is_ok());
+                let PushInfo { kind, data } = result.unwrap();
+                assert_eq!(
+                    (kind, data),
+                    (
+                        PushKind::SMessage,
+                        vec![
+                            Value::BulkString("test_channel_?".into()),
+                            Value::BulkString("test_message".into()),
+                        ]
+                    )
+                );
+            }
 
-        //     assert_eq!(
-        //         result,
-        //         Ok(Value::Push {
-        //             kind: PushKind::Subscribe,
-        //             data: vec![Value::BulkString("test_channel_?".into()), Value::Int(1)],
-        //         })
-        //     );
-
-        //     // pull out all the subscribe notification, this push notification is due to the previous subscribe command
-        //     let result = rx.recv().await;
-        //     assert!(result.is_some());
-        //     let PushInfo { kind, data } = result.unwrap();
-        //     assert_eq!(
-        //         (kind, data),
-        //         (
-        //             PushKind::Subscribe,
-        //             vec![
-        //                 Value::BulkString("test_channel_?".as_bytes().to_vec()),
-        //                 Value::Int(1),
-        //             ]
-        //         )
-        //     );
-
-        //     // ensure subscription, routing on the last node, expected return Int(1)
-        //     let result = connection
-        //     .route_command(&redis::Cmd::new().arg("PUBLISH").arg("test_channel_?").arg("test_message_from_node_5"), RoutingInfo::SingleNode(node_5_route.clone()))
-        //     .await;
-        //     assert_eq!(
-        //         result,
-        //         Ok(Value::Int(1))
-        //     );
-
-        //     // ensure subscription, routing on the first node, expected return Int(0)
-        //     let result = connection
-        //     .route_command(&redis::Cmd::new().arg("PUBLISH").arg("test_channel_?").arg("test_message_from_node_0"), RoutingInfo::SingleNode(node_0_route.clone()))
-        //     .await;
-        //     assert_eq!(
-        //         result,
-        //         Ok(Value::Int(0))
-        //     );
-
-        //     for i in vec![5, 0] {
-        //         let result = rx.recv().await;
-        //         assert!(result.is_some());
-        //         let PushInfo { kind, data } = result.unwrap();
-        //         println!("^^^^^^^^^ '{:?} -> {:?}'", kind, data);
-        //         assert_eq!(
-        //             (kind, data),
-        //             (
-        //                 PushKind::Message,
-        //                 vec![
-        //                     Value::BulkString("test_channel_?".into()),
-        //                     Value::BulkString(format!("test_message_from_node_{}", i).into()),
-        //                 ]
-        //             )
-        //         );
-        //     }
-
-        //     // drop and recreate cluster and connections
-        //     drop(cluster);
-        //     println!("*********** DROPPED **********");
-
-        //     let cluster = TestClusterContext::new_with_cluster_client_builder(
-        //         3,
-        //         0,
-        //         |builder| builder.retries(3).use_protocol(ProtocolVersion::RESP3),
-        //         //|builder| builder.retries(3),
-        //         false,
-        //     );
-
-        //     // ensure subscription state restore
-        //     let node_2_route = redis::cluster_routing::SingleNodeRoutingInfo::SpecificNode(slot_14212_route);
-        //     let result = connection
-        //     .route_command(&redis::Cmd::new().arg("PUBLISH").arg("test_channel_?").arg("test_message_from_node_2"), RoutingInfo::SingleNode(node_2_route.clone()))
-        //     .await;
-        //     assert_eq!(
-        //         result,
-        //         Ok(Value::Int(1))
-        //     );
-
-        //     // non-subscribed channel
-        //     let result = connection
-        //     .route_command(&redis::Cmd::new().arg("PUBLISH").arg("test_channel_1").arg("should_not_receive"), RoutingInfo::SingleNode(node_0_route.clone()))
-        //     .await;
-        //     assert_eq!(
-        //         result,
-        //         Ok(Value::Int(0))
-        //     );
-
-        //     // ensure subscription, routing on different node, expected return Int(0)
-        //     let result = connection
-        //     .route_command(&redis::Cmd::new().arg("PUBLISH").arg("test_channel_?").arg("test_message_from_node_2"), RoutingInfo::SingleNode(node_0_route.clone()))
-        //     .await;
-        //     assert_eq!(
-        //         result,
-        //         Ok(Value::Int(0))
-        //     );
-
-        //     // should produce an arbitrary number of 'disconnected' notifications - 1 for the intitial try after the drop and an unknown? amout during reconnecting procedure
-        //     // Notifications become available ONLY after we try to send the commands, since push manager does not register TCP disconnect on a idle socket
-        //     // Remove the any amount of 'disconnected' notifications
-        //     sleep(futures_time::time::Duration::from_secs(1)).await;
-        //     //let mut result = rx.recv().await;
-        //     let mut result = rx.try_recv();
-        //     assert!(result.is_ok());
-        //     //assert!(result.is_some());
-        //     loop {
-        //         let kind = result.clone().unwrap().kind;
-        //         if kind != PushKind::Disconnection && kind != PushKind::Subscribe {
-        //             break;
-        //         }
-        //         // result = rx.recv().await;
-        //         // assert!(result.is_some());
-        //         result = rx.try_recv();
-        //         assert!(result.is_ok());
-        //     }
-
-        //     // ensure messages test_message_from_node_0 and test_message_from_node_2
-        //     let mut msg_from_0 = false;
-        //     let mut msg_from_2 = false;
-        //     while !msg_from_0 && !msg_from_2 {
-        //         let mut result = rx.recv().await;
-        //         assert!(result.is_some());
-        //         let PushInfo { kind, data } = result.unwrap();
-
-        //         assert!(kind == PushKind::Disconnection || kind == PushKind::Subscribe || kind == PushKind::Message);
-        //         if kind == PushKind::Disconnection || kind == PushKind::Subscribe {
-        //             // ignore
-        //             continue;
-        //         }
-
-        //         if data == vec![
-        //             Value::BulkString("test_channel".into()),
-        //             Value::BulkString("test_message_from_node_0".into())] {
-        //             assert!(!msg_from_0);
-        //             msg_from_0 = true;
-        //         }
-        //         else if data == vec![
-        //             Value::BulkString("test_channel".into()),
-        //             Value::BulkString("test_message_from_node_2".into())] {
-        //             assert!(!msg_from_2);
-        //             msg_from_2 = true;
-        //         }
-        //         else {
-        //             assert!(false, "Unexpected message received");
-        //         }
-        //     }
-
-        //     Ok(())
-        // })
-        // .unwrap();
+            Ok(())
+        })
+        .unwrap();
     }
 
-    //#[allow(unreachable_code)]
+    #[test]
+    fn test_async_cluster_restore_resp3_pubsub_state_after_scale_out() {
+        let redis_ver = std::env::var("REDIS_VERSION").unwrap_or_default();
+        let use_sharded = redis_ver.starts_with("7.");
+
+        let mut client_subscriptions = PubSubSubscriptionInfo::from([
+            // test_channel_? is used as it maps to 14212 slot, which is the last node in both 3 and 6 node config
+            // (assuming slots allocation is monotonicaly increasing starting from node 0)
+            (
+                PubSubSubscriptionKind::Exact,
+                HashSet::from([PubSubChannelOrPattern::from("test_channel_?".as_bytes())]),
+            ),
+        ]);
+
+        if use_sharded {
+            client_subscriptions.insert(
+                PubSubSubscriptionKind::Sharded,
+                HashSet::from([PubSubChannelOrPattern::from("test_channel_?".as_bytes())]),
+            );
+        }
+
+        let slot_14212 = get_slot(b"test_channel_?");
+        assert_eq!(slot_14212, 14212);
+
+        let cluster = TestClusterContext::new_with_cluster_client_builder(
+            3,
+            0,
+            |builder| {
+                builder
+            .retries(3)
+            .use_protocol(ProtocolVersion::RESP3)
+            .pubsub_subscriptions(client_subscriptions.clone())
+            // periodic connection check is required to detect the disconnect from the last node
+            .periodic_connections_checks(Duration::from_secs(1))
+            // periodic topology check is required to detect topology change
+            .periodic_topology_checks(Duration::from_secs(1))
+            .slots_refresh_rate_limit(Duration::from_secs(0), 0)
+            },
+            false,
+        );
+
+        block_on_all(async move {
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<PushInfo>();
+            let mut _listening_con = cluster.async_connection(Some(tx.clone())).await;
+            // Note, publishing connection has the same pubsub config
+            let mut publishing_con = cluster.async_connection(None).await;
+
+            // short sleep to allow the server to push subscription notification
+            sleep(futures_time::time::Duration::from_secs(1)).await;
+
+            // validate subscriptions
+            validate_subscriptions(&client_subscriptions, &mut rx, false);
+
+            // validate PUBLISH
+            let result = cmd("PUBLISH")
+                .arg("test_channel_?")
+                .arg("test_message")
+                .query_async(&mut publishing_con)
+                .await;
+            assert_eq!(
+                result,
+                Ok(Value::Int(2)) // 2 connections with the same pubsub config
+            );
+
+            sleep(futures_time::time::Duration::from_secs(1)).await;
+            let result = rx.try_recv();
+            assert!(result.is_ok());
+            let PushInfo { kind, data } = result.unwrap();
+            assert_eq!(
+                (kind, data),
+                (
+                    PushKind::Message,
+                    vec![
+                        Value::BulkString("test_channel_?".into()),
+                        Value::BulkString("test_message".into()),
+                    ]
+                )
+            );
+
+            if use_sharded {
+                // validate SPUBLISH
+                let result = cmd("SPUBLISH")
+                    .arg("test_channel_?")
+                    .arg("test_message")
+                    .query_async(&mut publishing_con)
+                    .await;
+                assert_eq!(
+                    result,
+                    Ok(Value::Int(2)) // 2 connections with the same pubsub config
+                );
+
+                sleep(futures_time::time::Duration::from_secs(1)).await;
+                let result = rx.try_recv();
+                assert!(result.is_ok());
+                let PushInfo { kind, data } = result.unwrap();
+                assert_eq!(
+                    (kind, data),
+                    (
+                        PushKind::SMessage,
+                        vec![
+                            Value::BulkString("test_channel_?".into()),
+                            Value::BulkString("test_message".into()),
+                        ]
+                    )
+                );
+            }
+
+            // drop and recreate a cluster with more nodes
+            drop(cluster);
+
+            // recreate the cluster, the assumtion is that the cluster is built with exactly the same params (ports, slots map...)
+            let cluster =
+                TestClusterContext::new_with_cluster_client_builder(6, 0, |builder| builder, false);
+
+            // assume slot 14212 will reside in the last node
+            let last_server_port = {
+                let addr = cluster.cluster.servers.last().unwrap().addr.clone();
+                match addr {
+                    redis::ConnectionAddr::TcpTls {
+                        host: _,
+                        port,
+                        insecure: _,
+                        tls_params: _,
+                    } => port,
+                    redis::ConnectionAddr::Tcp(_, port) => port,
+                    _ => {
+                        panic!("Wrong server address type: {:?}", addr);
+                    }
+                }
+            };
+
+            // wait for new topology discovery
+            loop {
+                let mut cmd = redis::cmd("INFO");
+                cmd.arg("SERVER");
+                let res = publishing_con
+                    .route_command(
+                        &cmd,
+                        RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(Route::new(
+                            slot_14212,
+                            SlotAddr::Master,
+                        ))),
+                    )
+                    .await;
+                assert!(res.is_ok());
+                let res = res.unwrap();
+                match res {
+                    Value::VerbatimString { format: _, text } => {
+                        if text.contains(format!("tcp_port:{}", last_server_port).as_str()) {
+                            // new topology rediscovered
+                            break;
+                        }
+                    }
+                    _ => {
+                        panic!("Wrong return type for INFO SERVER command: {:?}", res);
+                    }
+                }
+                sleep(futures_time::time::Duration::from_secs(1)).await;
+            }
+
+            // sleep for one one cycle of topology refresh
+            sleep(futures_time::time::Duration::from_secs(1)).await;
+
+            // validate PUBLISH
+            let result = redis::cmd("PUBLISH")
+                .arg("test_channel_?")
+                .arg("test_message")
+                .query_async(&mut publishing_con)
+                .await;
+            assert_eq!(
+                result,
+                Ok(Value::Int(2)) // 2 connections with the same pubsub config
+            );
+
+            // allow message to propagate
+            sleep(futures_time::time::Duration::from_secs(1)).await;
+
+            loop {
+                let result = rx.try_recv();
+                assert!(result.is_ok());
+                let PushInfo { kind, data } = result.unwrap();
+                // ignore disconnection and subscription notifications due to resubscriptions
+                if kind == PushKind::Message {
+                    assert_eq!(
+                        data,
+                        vec![
+                            Value::BulkString("test_channel_?".into()),
+                            Value::BulkString("test_message".into()),
+                        ]
+                    );
+                    break;
+                }
+            }
+
+            if use_sharded {
+                // validate SPUBLISH
+                let result = cmd("SPUBLISH")
+                    .arg("test_channel_?")
+                    .arg("test_message")
+                    .query_async(&mut publishing_con)
+                    .await;
+                assert_eq!(
+                    result,
+                    Ok(Value::Int(2)) // 2 connections with the same pubsub config
+                );
+
+                // allow message to propagate
+                sleep(futures_time::time::Duration::from_secs(1)).await;
+
+                let result = rx.try_recv();
+                assert!(result.is_ok());
+                let PushInfo { kind, data } = result.unwrap();
+                assert_eq!(
+                    (kind, data),
+                    (
+                        PushKind::SMessage,
+                        vec![
+                            Value::BulkString("test_channel_?".into()),
+                            Value::BulkString("test_message".into()),
+                        ]
+                    )
+                );
+            }
+
+            drop(publishing_con);
+            drop(_listening_con);
+
+            Ok(())
+        })
+        .unwrap();
+
+        block_on_all(async move {
+            sleep(futures_time::time::Duration::from_secs(10)).await;
+            Ok(())
+        })
+        .unwrap();
+    }
+
     #[test]
     fn test_async_cluster_resp3_pubsub() {
         let redis_ver = std::env::var("REDIS_VERSION").unwrap_or_default();
@@ -3268,39 +3304,10 @@ mod cluster_async {
             // short sleep to allow the server to push subscription notification
             sleep(futures_time::time::Duration::from_secs(1)).await;
 
-            let mut subscribe_cnt = client_subscriptions[&PubSubSubscriptionKind::Exact].len();
-            let mut psubscribe_cnt = client_subscriptions[&PubSubSubscriptionKind::Pattern].len();
-            let mut ssubscribe_cnt = 0;
-            if let Some(sharded_shubs) = client_subscriptions.get(&PubSubSubscriptionKind::Sharded)
-            {
-                ssubscribe_cnt += sharded_shubs.len()
-            }
-            for _ in 0..(subscribe_cnt + psubscribe_cnt + ssubscribe_cnt) {
-                let result = rx.try_recv();
-                assert!(result.is_ok());
-                let PushInfo { kind, data: _ } = result.unwrap();
-                assert!(
-                    kind == PushKind::Subscribe
-                        || kind == PushKind::PSubscribe
-                        || kind == PushKind::SSubscribe
-                );
-                if kind == PushKind::Subscribe {
-                    subscribe_cnt -= 1;
-                } else if kind == PushKind::PSubscribe {
-                    psubscribe_cnt -= 1;
-                } else {
-                    ssubscribe_cnt -= 1;
-                }
-            }
-
-            assert!(subscribe_cnt == 0);
-            assert!(psubscribe_cnt == 0);
-            assert!(ssubscribe_cnt == 0);
+            validate_subscriptions(&client_subscriptions, &mut rx, false);
 
             let slot_14212 = get_slot(b"test_channel_?");
             assert_eq!(slot_14212, 14212);
-            //let slot_14212_route = redis::cluster_routing::Route::new(slot_14212, redis::cluster_routing::SlotAddr::Master);
-            //let node_5_route = redis::cluster_routing::SingleNodeRoutingInfo::SpecificNode(slot_14212_route);
 
             let slot_0_route =
                 redis::cluster_routing::Route::new(0, redis::cluster_routing::SlotAddr::Master);

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -21,7 +21,7 @@ mod cluster_async {
     use std::ops::Add;
 
     use redis::{
-        aio::{ConnectionLike, DisconnectNotifier, MultiplexedConnection},
+        aio::{ConnectionLike, MultiplexedConnection},
         cluster::ClusterClient,
         cluster_async::{testing::MANAGEMENT_CONN_NAME, ClusterConnection, Connect},
         cluster_routing::{
@@ -29,9 +29,9 @@ mod cluster_async {
         },
         cluster_topology::{get_slot, DEFAULT_NUMBER_OF_REFRESH_SLOTS_RETRIES},
         cmd, from_owned_redis_value, parse_redis_value, AsyncCommands, Cmd, ErrorKind,
-        FromRedisValue, InfoDict, IntoConnectionInfo, ProtocolVersion, PubSubChannelOrPattern,
-        PubSubSubscriptionInfo, PubSubSubscriptionKind, PushInfo, PushKind, RedisError,
-        RedisFuture, RedisResult, Script, Value,
+        FromRedisValue, GlideConnectionOptions, InfoDict, IntoConnectionInfo, ProtocolVersion,
+        PubSubChannelOrPattern, PubSubSubscriptionInfo, PubSubSubscriptionKind, PushInfo, PushKind,
+        RedisError, RedisFuture, RedisResult, Script, Value,
     };
 
     use crate::support::*;
@@ -436,7 +436,7 @@ mod cluster_async {
                         .unwrap_or_else(|e| panic!("Failed to connect to '{addr}': {e}"));
 
                     let mut conn = client
-                        .get_multiplexed_async_connection(None, None)
+                        .get_multiplexed_async_connection(GlideConnectionOptions::default())
                         .await
                         .unwrap_or_else(|e| panic!("Failed to get connection: {e}"));
 
@@ -535,8 +535,7 @@ mod cluster_async {
             response_timeout: std::time::Duration,
             connection_timeout: std::time::Duration,
             socket_addr: Option<SocketAddr>,
-            push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
-            disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
+            glide_connection_options: GlideConnectionOptions,
         ) -> RedisFuture<'a, (Self, Option<IpAddr>)>
         where
             T: IntoConnectionInfo + Send + 'a,
@@ -547,8 +546,7 @@ mod cluster_async {
                     response_timeout,
                     connection_timeout,
                     socket_addr,
-                    push_sender,
-                    disconnect_notifier,
+                    glide_connection_options,
                 )
                 .await?;
                 Ok((ErrorConnection { inner }, None))

--- a/redis/tests/test_sentinel.rs
+++ b/redis/tests/test_sentinel.rs
@@ -239,7 +239,7 @@ pub mod async_tests {
     use redis::{
         aio::MultiplexedConnection,
         sentinel::{Sentinel, SentinelClient, SentinelNodeConnectionInfo},
-        Client, ConnectionAddr, RedisError,
+        Client, ConnectionAddr, GlideConnectionOptions, RedisError,
     };
 
     use crate::{assert_is_master_role, assert_replica_role_and_master_addr, support::*};
@@ -283,7 +283,7 @@ pub mod async_tests {
                 .await
                 .unwrap();
             let mut replica_con = replica_client
-                .get_multiplexed_async_connection(None, None)
+                .get_multiplexed_async_connection(GlideConnectionOptions::default())
                 .await
                 .unwrap();
 
@@ -316,7 +316,7 @@ pub mod async_tests {
                 .await
                 .unwrap();
             let mut replica_con = replica_client
-                .get_multiplexed_async_connection(None, None)
+                .get_multiplexed_async_connection(GlideConnectionOptions::default())
                 .await
                 .unwrap();
 
@@ -339,13 +339,13 @@ pub mod async_tests {
                 .async_master_for(master_name, Some(&node_conn_info))
                 .await?;
             let mut master_con = master_client
-                .get_multiplexed_async_connection(None, None)
+                .get_multiplexed_async_connection(GlideConnectionOptions::default())
                 .await?;
 
             let mut replica_con = sentinel
                 .async_replica_for(master_name, Some(&node_conn_info))
                 .await?
-                .get_multiplexed_async_connection(None, None)
+                .get_multiplexed_async_connection(GlideConnectionOptions::default())
                 .await?;
 
             async_assert_is_connection_to_master(&mut master_con).await;
@@ -370,7 +370,7 @@ pub mod async_tests {
                 .async_master_for(master_name, Some(&node_conn_info))
                 .await?;
             let mut master_con = master_client
-                .get_multiplexed_async_connection(None, None)
+                .get_multiplexed_async_connection(GlideConnectionOptions::default())
                 .await?;
 
             async_assert_is_connection_to_master(&mut master_con).await;
@@ -413,7 +413,7 @@ pub mod async_tests {
                 .async_master_for(master_name, Some(&node_conn_info))
                 .await?;
             let mut master_con = master_client
-                .get_multiplexed_async_connection(None, None)
+                .get_multiplexed_async_connection(GlideConnectionOptions::default())
                 .await?;
 
             async_assert_is_connection_to_master(&mut master_con).await;

--- a/redis/tests/test_sentinel.rs
+++ b/redis/tests/test_sentinel.rs
@@ -283,7 +283,7 @@ pub mod async_tests {
                 .await
                 .unwrap();
             let mut replica_con = replica_client
-                .get_multiplexed_async_connection(None)
+                .get_multiplexed_async_connection(None, None)
                 .await
                 .unwrap();
 
@@ -316,7 +316,7 @@ pub mod async_tests {
                 .await
                 .unwrap();
             let mut replica_con = replica_client
-                .get_multiplexed_async_connection(None)
+                .get_multiplexed_async_connection(None, None)
                 .await
                 .unwrap();
 
@@ -338,12 +338,14 @@ pub mod async_tests {
             let master_client = sentinel
                 .async_master_for(master_name, Some(&node_conn_info))
                 .await?;
-            let mut master_con = master_client.get_multiplexed_async_connection(None).await?;
+            let mut master_con = master_client
+                .get_multiplexed_async_connection(None, None)
+                .await?;
 
             let mut replica_con = sentinel
                 .async_replica_for(master_name, Some(&node_conn_info))
                 .await?
-                .get_multiplexed_async_connection(None)
+                .get_multiplexed_async_connection(None, None)
                 .await?;
 
             async_assert_is_connection_to_master(&mut master_con).await;
@@ -367,7 +369,9 @@ pub mod async_tests {
             let master_client = sentinel
                 .async_master_for(master_name, Some(&node_conn_info))
                 .await?;
-            let mut master_con = master_client.get_multiplexed_async_connection(None).await?;
+            let mut master_con = master_client
+                .get_multiplexed_async_connection(None, None)
+                .await?;
 
             async_assert_is_connection_to_master(&mut master_con).await;
 
@@ -408,7 +412,9 @@ pub mod async_tests {
             let master_client = sentinel
                 .async_master_for(master_name, Some(&node_conn_info))
                 .await?;
-            let mut master_con = master_client.get_multiplexed_async_connection(None).await?;
+            let mut master_con = master_client
+                .get_multiplexed_async_connection(None, None)
+                .await?;
 
             async_assert_is_connection_to_master(&mut master_con).await;
 


### PR DESCRIPTION
Introduce a fast reconnect process for async cluster connections.
The process is periodic and can be configured via ClusterParams.
This process ensures that all expected user connections exist and have not been passively closed.
The expected connections are calculated from the current slot map.
Additionally, for the Tokio runtime, an instant disconnect notification is available, allowing the reconnect process to be triggered instantly without waiting for the periodic check.
This process is especially important for pub/sub support, as passive disconnects can render a pub/sub subscriber inoperative. Three integration tests are introduced with this feature: a generic fast reconnect test, pub/sub resilience to passive disconnects, and pub/sub resilience to scale-out.

**Note!** This PR must be followed by a PR to glide-core. implementing the similar functionality for CMD

*Issue #, if available:*
https://github.com/valkey-io/valkey-glide/issues/2042

