### PR TITLE
SlotMap refactor: Added NodesMap, sharing shard addresses between shard nodes and slot map values.

### DIFF
--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -35,13 +35,13 @@
 //!     .expire(key, 60).ignore()
 //!     .query(&mut connection).unwrap();
 //! ```
+use rand::{seq::IteratorRandom, thread_rng, Rng};
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
-
-use rand::{seq::IteratorRandom, thread_rng, Rng};
 
 use crate::cluster_pipeline::UNROUTABLE_ERROR;
 use crate::cluster_routing::{
@@ -343,22 +343,20 @@ where
         let mut slots = self.slots.borrow_mut();
         *slots = self.create_new_slots()?;
 
-        let mut nodes = slots.values().flatten().collect::<Vec<_>>();
-        nodes.sort_unstable();
-        nodes.dedup();
-
+        let nodes = slots.all_node_addresses();
         let mut connections = self.connections.borrow_mut();
         *connections = nodes
             .into_iter()
             .filter_map(|addr| {
-                if connections.contains_key(addr) {
-                    let mut conn = connections.remove(addr).unwrap();
+                let addr = addr.to_string();
+                if connections.contains_key(&addr) {
+                    let mut conn = connections.remove(&addr).unwrap();
                     if conn.check_connection() {
                         return Some((addr.to_string(), conn));
                     }
                 }
 
-                if let Ok(mut conn) = self.connect(addr) {
+                if let Ok(mut conn) = self.connect(&addr) {
                     if conn.check_connection() {
                         return Some((addr.to_string(), conn));
                     }
@@ -424,7 +422,7 @@ where
         if let Some(addr) = slots.slot_addr_for_route(route) {
             Ok((
                 addr.to_string(),
-                self.get_connection_by_addr(connections, addr)?,
+                self.get_connection_by_addr(connections, &addr)?,
             ))
         } else {
             // try a random node next.  This is safe if slots are involved
@@ -495,13 +493,13 @@ where
     fn execute_on_all<'a>(
         &'a self,
         input: Input,
-        addresses: HashSet<&'a str>,
+        addresses: HashSet<Arc<String>>,
         connections: &'a mut HashMap<String, C>,
-    ) -> Vec<RedisResult<(&'a str, Value)>> {
+    ) -> Vec<RedisResult<(Arc<String>, Value)>> {
         addresses
             .into_iter()
             .map(|addr| {
-                let connection = self.get_connection_by_addr(connections, addr)?;
+                let connection = self.get_connection_by_addr(connections, &addr)?;
                 match input {
                     Input::Slice { cmd, routable: _ } => connection.req_packed_command(cmd),
                     Input::Cmd(cmd) => connection.req_command(cmd),
@@ -526,8 +524,8 @@ where
         input: Input,
         slots: &'a mut SlotMap,
         connections: &'a mut HashMap<String, C>,
-    ) -> Vec<RedisResult<(&'a str, Value)>> {
-        self.execute_on_all(input, slots.addresses_for_all_nodes(), connections)
+    ) -> Vec<RedisResult<(Arc<String>, Value)>> {
+        self.execute_on_all(input, slots.all_node_addresses(), connections)
     }
 
     fn execute_on_all_primaries<'a>(
@@ -535,7 +533,7 @@ where
         input: Input,
         slots: &'a mut SlotMap,
         connections: &'a mut HashMap<String, C>,
-    ) -> Vec<RedisResult<(&'a str, Value)>> {
+    ) -> Vec<RedisResult<(Arc<String>, Value)>> {
         self.execute_on_all(input, slots.addresses_for_all_primaries(), connections)
     }
 
@@ -545,7 +543,7 @@ where
         slots: &'a mut SlotMap,
         connections: &'a mut HashMap<String, C>,
         routes: &'b [(Route, Vec<usize>)],
-    ) -> Vec<RedisResult<(&'a str, Value)>>
+    ) -> Vec<RedisResult<(Arc<String>, Value)>>
     where
         'b: 'a,
     {
@@ -557,7 +555,7 @@ where
                     ErrorKind::IoError,
                     "Couldn't find connection",
                 )))?;
-                let connection = self.get_connection_by_addr(connections, addr)?;
+                let connection = self.get_connection_by_addr(connections, &addr)?;
                 let (_, indices) = routes.get(index).unwrap();
                 let cmd =
                     crate::cluster_routing::command_for_multi_slot_indices(&input, indices.iter());

--- a/redis/src/cluster_async/connections_container.rs
+++ b/redis/src/cluster_async/connections_container.rs
@@ -147,18 +147,14 @@ where
 
     /// Returns true if the address represents a known primary node.
     pub(crate) fn is_primary(&self, address: &String) -> bool {
-        self.connection_for_address(address).is_some()
-            && self
-                .slot_map
-                .values()
-                .any(|slot_addrs| slot_addrs.primary.as_str() == address)
+        self.connection_for_address(address).is_some() && self.slot_map.is_primary(address)
     }
 
     fn round_robin_read_from_replica(
         &self,
         slot_map_value: &SlotMapValue,
     ) -> Option<ConnectionAndAddress<Connection>> {
-        let addrs = &slot_map_value.addrs;
+        let addrs = &slot_map_value.addrs.read().unwrap();
         let initial_index = slot_map_value
             .latest_used_replica
             .load(std::sync::atomic::Ordering::Relaxed);
@@ -185,7 +181,7 @@ where
 
     fn lookup_route(&self, route: &Route) -> Option<ConnectionAndAddress<Connection>> {
         let slot_map_value = self.slot_map.slot_value_for_route(route)?;
-        let addrs = &slot_map_value.addrs;
+        let addrs = &slot_map_value.addrs.read().unwrap();
         if addrs.replicas.is_empty() {
             return self.connection_for_address(addrs.primary.as_str());
         }
@@ -232,7 +228,7 @@ where
         self.slot_map
             .addresses_for_all_primaries()
             .into_iter()
-            .flat_map(|addr| self.connection_for_address(addr))
+            .flat_map(|addr| self.connection_for_address(&addr))
     }
 
     pub(crate) fn node_for_address(&self, address: &str) -> Option<ClusterNode<Connection>> {

--- a/redis/src/cluster_async/connections_container.rs
+++ b/redis/src/cluster_async/connections_container.rs
@@ -154,21 +154,25 @@ where
         &self,
         slot_map_value: &SlotMapValue,
     ) -> Option<ConnectionAndAddress<Connection>> {
-        let addrs = &slot_map_value.addrs.read().unwrap();
+        let addrs = &slot_map_value
+            .addrs
+            .read()
+            .expect("Failed to obtain ShardAddrs's read lock");
         let initial_index = slot_map_value
-            .latest_used_replica
+            .last_used_replica
             .load(std::sync::atomic::Ordering::Relaxed);
         let mut check_count = 0;
         loop {
             check_count += 1;
 
             // Looped through all replicas, no connected replica was found.
-            if check_count > addrs.replicas.len() {
-                return self.connection_for_address(addrs.primary.as_str());
+            if check_count > addrs.replicas().len() {
+                return self.connection_for_address(addrs.primary().as_str());
             }
-            let index = (initial_index + check_count) % addrs.replicas.len();
-            if let Some(connection) = self.connection_for_address(addrs.replicas[index].as_str()) {
-                let _ = slot_map_value.latest_used_replica.compare_exchange_weak(
+            let index = (initial_index + check_count) % addrs.replicas().len();
+            if let Some(connection) = self.connection_for_address(addrs.replicas()[index].as_str())
+            {
+                let _ = slot_map_value.last_used_replica.compare_exchange_weak(
                     initial_index,
                     index,
                     std::sync::atomic::Ordering::Relaxed,
@@ -181,16 +185,19 @@ where
 
     fn lookup_route(&self, route: &Route) -> Option<ConnectionAndAddress<Connection>> {
         let slot_map_value = self.slot_map.slot_value_for_route(route)?;
-        let addrs = &slot_map_value.addrs.read().unwrap();
-        if addrs.replicas.is_empty() {
-            return self.connection_for_address(addrs.primary.as_str());
+        let addrs = &slot_map_value
+            .addrs
+            .read()
+            .expect("Failed to obtain ShardAddrs's read lock");
+        if addrs.replicas().is_empty() {
+            return self.connection_for_address(addrs.primary().as_str());
         }
 
         match route.slot_addr() {
-            SlotAddr::Master => self.connection_for_address(addrs.primary.as_str()),
+            SlotAddr::Master => self.connection_for_address(addrs.primary().as_str()),
             SlotAddr::ReplicaOptional => match self.read_from_replica_strategy {
                 ReadFromReplicaStrategy::AlwaysFromPrimary => {
-                    self.connection_for_address(addrs.primary.as_str())
+                    self.connection_for_address(addrs.primary().as_str())
                 }
                 ReadFromReplicaStrategy::RoundRobin => {
                     self.round_robin_read_from_replica(slot_map_value)

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -896,8 +896,22 @@ pub enum SlotAddr {
 /// a command is executed
 #[derive(Debug, Eq, PartialEq, Clone, PartialOrd, Ord)]
 pub(crate) struct ShardAddrs {
-    pub(crate) primary: Arc<String>,
-    pub(crate) replicas: Vec<Arc<String>>,
+    primary: Arc<String>,
+    replicas: Vec<Arc<String>>,
+}
+
+impl ShardAddrs {
+    pub(crate) fn new(primary: Arc<String>, replicas: Vec<Arc<String>>) -> Self {
+        Self { primary, replicas }
+    }
+
+    pub(crate) fn primary(&self) -> Arc<String> {
+        self.primary.clone()
+    }
+
+    pub(crate) fn replicas(&self) -> &Vec<Arc<String>> {
+        self.replicas.as_ref()
+    }
 }
 
 impl<'a> IntoIterator for &'a ShardAddrs {

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -1,11 +1,11 @@
-use std::cmp::min;
-use std::collections::HashMap;
-
 use crate::cluster_topology::get_slot;
 use crate::cmd::{Arg, Cmd};
 use crate::types::Value;
 use crate::{ErrorKind, RedisResult};
+use std::cmp::min;
+use std::collections::HashMap;
 use std::iter::Once;
+use std::sync::Arc;
 
 #[derive(Clone)]
 pub(crate) enum Redirect {
@@ -866,14 +866,6 @@ impl Slot {
         }
     }
 
-    pub fn start(&self) -> u16 {
-        self.start
-    }
-
-    pub fn end(&self) -> u16 {
-        self.end
-    }
-
     #[allow(dead_code)] // used in tests
     pub(crate) fn master(&self) -> &str {
         self.master.as_str()
@@ -902,25 +894,15 @@ pub enum SlotAddr {
 /// which stores only the master and [optional] replica
 /// to avoid the need to choose a replica each time
 /// a command is executed
-#[derive(Debug, Eq, PartialEq)]
-pub(crate) struct SlotAddrs {
-    pub(crate) primary: String,
-    pub(crate) replicas: Vec<String>,
+#[derive(Debug, Eq, PartialEq, Clone, PartialOrd, Ord)]
+pub(crate) struct ShardAddrs {
+    pub(crate) primary: Arc<String>,
+    pub(crate) replicas: Vec<Arc<String>>,
 }
 
-impl SlotAddrs {
-    pub(crate) fn new(primary: String, replicas: Vec<String>) -> Self {
-        Self { primary, replicas }
-    }
-
-    pub(crate) fn from_slot(slot: Slot) -> Self {
-        SlotAddrs::new(slot.master, slot.replicas)
-    }
-}
-
-impl<'a> IntoIterator for &'a SlotAddrs {
-    type Item = &'a String;
-    type IntoIter = std::iter::Chain<Once<&'a String>, std::slice::Iter<'a, String>>;
+impl<'a> IntoIterator for &'a ShardAddrs {
+    type Item = &'a Arc<String>;
+    type IntoIter = std::iter::Chain<Once<&'a Arc<String>>, std::slice::Iter<'a, Arc<String>>>;
 
     fn into_iter(self) -> Self::IntoIter {
         std::iter::once(&self.primary).chain(self.replicas.iter())

--- a/redis/src/cluster_slotmap.rs
+++ b/redis/src/cluster_slotmap.rs
@@ -1,26 +1,22 @@
+use std::sync::Arc;
+use std::sync::RwLock;
 use std::{
     collections::{BTreeMap, HashSet},
     fmt::Display,
     sync::atomic::AtomicUsize,
 };
 
-use crate::cluster_routing::{Route, Slot, SlotAddr, SlotAddrs};
+use dashmap::DashMap;
+
+use crate::cluster_routing::{Route, ShardAddrs, Slot, SlotAddr};
+
+pub(crate) type NodesMap = DashMap<Arc<String>, Arc<RwLock<ShardAddrs>>>;
 
 #[derive(Debug)]
 pub(crate) struct SlotMapValue {
     pub(crate) start: u16,
-    pub(crate) addrs: SlotAddrs,
+    pub(crate) addrs: Arc<RwLock<ShardAddrs>>,
     pub(crate) latest_used_replica: AtomicUsize,
-}
-
-impl SlotMapValue {
-    fn from_slot(slot: Slot) -> Self {
-        Self {
-            start: slot.start(),
-            addrs: SlotAddrs::from_slot(slot),
-            latest_used_replica: AtomicUsize::new(0),
-        }
-    }
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Copy)]
@@ -33,6 +29,7 @@ pub(crate) enum ReadFromReplicaStrategy {
 #[derive(Debug, Default)]
 pub(crate) struct SlotMap {
     pub(crate) slots: BTreeMap<u16, SlotMapValue>,
+    pub(crate) nodes_map: NodesMap,
     read_from_replica: ReadFromReplicaStrategy,
 }
 
@@ -40,34 +37,75 @@ fn get_address_from_slot(
     slot: &SlotMapValue,
     read_from_replica: ReadFromReplicaStrategy,
     slot_addr: SlotAddr,
-) -> &str {
-    if slot_addr == SlotAddr::Master || slot.addrs.replicas.is_empty() {
-        return slot.addrs.primary.as_str();
+) -> Arc<String> {
+    let addrs = slot.addrs.read().unwrap();
+    if slot_addr == SlotAddr::Master || addrs.replicas.is_empty() {
+        return addrs.primary.clone();
     }
     match read_from_replica {
-        ReadFromReplicaStrategy::AlwaysFromPrimary => slot.addrs.primary.as_str(),
+        ReadFromReplicaStrategy::AlwaysFromPrimary => addrs.primary.clone(),
         ReadFromReplicaStrategy::RoundRobin => {
             let index = slot
                 .latest_used_replica
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                % slot.addrs.replicas.len();
-            slot.addrs.replicas[index].as_str()
+                % addrs.replicas.len();
+            addrs.replicas[index].clone()
         }
     }
 }
 
 impl SlotMap {
     pub(crate) fn new(slots: Vec<Slot>, read_from_replica: ReadFromReplicaStrategy) -> Self {
-        let mut this = Self {
+        let mut slot_map = SlotMap {
             slots: BTreeMap::new(),
+            nodes_map: DashMap::new(),
             read_from_replica,
         };
-        this.slots.extend(
-            slots
-                .into_iter()
-                .map(|slot| (slot.end(), SlotMapValue::from_slot(slot))),
-        );
-        this
+        let mut shard_id = 0;
+        for slot in slots {
+            let primary = Arc::new(slot.master);
+            let replicas: Vec<Arc<String>> = slot.replicas.into_iter().map(Arc::new).collect();
+
+            // Get the shard addresses if the primary is already in nodes_map;
+            // otherwise, create a new ShardAddrs and add it
+            let shard_addrs_arc = slot_map
+                .nodes_map
+                .entry(primary.clone())
+                .or_insert_with(|| {
+                    shard_id += 1;
+                    Arc::new(RwLock::new(ShardAddrs {
+                        primary,
+                        replicas: replicas.clone(),
+                    }))
+                })
+                .clone();
+
+            // Add all replicas to nodes_map with a reference to the same ShardAddrs if not already present
+            replicas.iter().for_each(|replica| {
+                slot_map
+                    .nodes_map
+                    .entry(replica.clone())
+                    .or_insert(shard_addrs_arc.clone());
+            });
+
+            // Insert the slot value into the slots map
+            slot_map.slots.insert(
+                slot.end,
+                SlotMapValue {
+                    addrs: shard_addrs_arc.clone(),
+                    start: slot.start,
+                    latest_used_replica: AtomicUsize::new(0),
+                },
+            );
+        }
+
+        slot_map
+    }
+
+    pub fn is_primary(&self, address: &String) -> bool {
+        self.nodes_map.get(address).map_or(false, |shard_addrs| {
+            *shard_addrs.read().unwrap().primary == *address
+        })
     }
 
     pub fn slot_value_for_route(&self, route: &Route) -> Option<&SlotMapValue> {
@@ -84,40 +122,36 @@ impl SlotMap {
             })
     }
 
-    pub fn slot_addr_for_route(&self, route: &Route) -> Option<&str> {
+    pub fn slot_addr_for_route(&self, route: &Route) -> Option<Arc<String>> {
         self.slot_value_for_route(route).map(|slot_value| {
             get_address_from_slot(slot_value, self.read_from_replica, route.slot_addr())
         })
     }
 
-    pub fn values(&self) -> impl Iterator<Item = &SlotAddrs> {
-        self.slots.values().map(|slot_value| &slot_value.addrs)
+    pub fn addresses_for_all_primaries(&self) -> HashSet<Arc<String>> {
+        self.nodes_map
+            .iter()
+            .map(|map_item| {
+                let shard_addrs = map_item.value();
+                shard_addrs.read().unwrap().primary.clone()
+            })
+            .collect()
     }
 
-    fn all_unique_addresses(&self, only_primaries: bool) -> HashSet<&str> {
-        let mut addresses = HashSet::new();
-        for slot in self.values() {
-            addresses.insert(slot.primary.as_str());
-            if !only_primaries {
-                addresses.extend(slot.replicas.iter().map(|str| str.as_str()));
-            }
-        }
-
-        addresses
-    }
-
-    pub fn addresses_for_all_primaries(&self) -> HashSet<&str> {
-        self.all_unique_addresses(true)
-    }
-
-    pub fn addresses_for_all_nodes(&self) -> HashSet<&str> {
-        self.all_unique_addresses(false)
+    pub fn all_node_addresses(&self) -> HashSet<Arc<String>> {
+        self.nodes_map
+            .iter()
+            .map(|map_item| {
+                let node_addr = map_item.key();
+                node_addr.clone()
+            })
+            .collect()
     }
 
     pub fn addresses_for_multi_slot<'a, 'b>(
         &'a self,
         routes: &'b [(Route, Vec<usize>)],
-    ) -> impl Iterator<Item = Option<&'a str>> + 'a
+    ) -> impl Iterator<Item = Option<Arc<String>>> + 'a
     where
         'b: 'a,
     {
@@ -127,13 +161,13 @@ impl SlotMap {
     }
 
     // Returns the slots that are assigned to the given address.
-    pub(crate) fn get_slots_of_node(&self, node_address: &str) -> Vec<u16> {
-        let node_address = node_address.to_string();
+    pub(crate) fn get_slots_of_node(&self, node_address: Arc<String>) -> Vec<u16> {
         self.slots
             .iter()
             .filter_map(|(end, slot_value)| {
-                if slot_value.addrs.primary == node_address
-                    || slot_value.addrs.replicas.contains(&node_address)
+                let addr_reader = slot_value.addrs.read().unwrap();
+                if addr_reader.primary == node_address
+                    || addr_reader.replicas.contains(&node_address)
                 {
                     Some(slot_value.start..(*end + 1))
                 } else {
@@ -148,13 +182,14 @@ impl SlotMap {
         &self,
         slot: u16,
         slot_addr: SlotAddr,
-    ) -> Option<String> {
+    ) -> Option<Arc<String>> {
         self.slots.range(slot..).next().and_then(|(_, slot_value)| {
             if slot_value.start <= slot {
-                Some(
-                    get_address_from_slot(slot_value, self.read_from_replica, slot_addr)
-                        .to_string(),
-                )
+                Some(get_address_from_slot(
+                    slot_value,
+                    self.read_from_replica,
+                    slot_addr,
+                ))
             } else {
                 None
             }
@@ -171,8 +206,8 @@ impl Display for SlotMap {
                 "({}-{}): primary: {}, replicas: {:?}",
                 slot_map_value.start,
                 end,
-                slot_map_value.addrs.primary,
-                slot_map_value.addrs.replicas
+                slot_map_value.addrs.read().unwrap().primary,
+                slot_map_value.addrs.read().unwrap().replicas
             )?;
         }
         Ok(())
@@ -180,8 +215,21 @@ impl Display for SlotMap {
 }
 
 #[cfg(test)]
-mod tests {
+mod tests_cluster_slotmap {
     use super::*;
+
+    fn process_expected(expected: Vec<&str>) -> HashSet<Arc<String>> {
+        <HashSet<&str> as IntoIterator>::into_iter(HashSet::from_iter(expected))
+            .map(|s| Arc::new(s.to_string()))
+            .collect()
+    }
+
+    fn process_expected_with_option(expected: Vec<Option<&str>>) -> Vec<Arc<String>> {
+        expected
+            .into_iter()
+            .filter_map(|opt| opt.map(|s| Arc::new(s.to_string())))
+            .collect()
+    }
 
     #[test]
     fn test_slot_map_retrieve_routes() {
@@ -208,19 +256,19 @@ mod tests {
             .is_none());
         assert_eq!(
             "node1:6379",
-            slot_map
+            *slot_map
                 .slot_addr_for_route(&Route::new(1, SlotAddr::Master))
                 .unwrap()
         );
         assert_eq!(
             "node1:6379",
-            slot_map
+            *slot_map
                 .slot_addr_for_route(&Route::new(500, SlotAddr::Master))
                 .unwrap()
         );
         assert_eq!(
             "node1:6379",
-            slot_map
+            *slot_map
                 .slot_addr_for_route(&Route::new(1000, SlotAddr::Master))
                 .unwrap()
         );
@@ -230,19 +278,19 @@ mod tests {
 
         assert_eq!(
             "node2:6379",
-            slot_map
+            *slot_map
                 .slot_addr_for_route(&Route::new(1002, SlotAddr::Master))
                 .unwrap()
         );
         assert_eq!(
             "node2:6379",
-            slot_map
+            *slot_map
                 .slot_addr_for_route(&Route::new(1500, SlotAddr::Master))
                 .unwrap()
         );
         assert_eq!(
             "node2:6379",
-            slot_map
+            *slot_map
                 .slot_addr_for_route(&Route::new(2000, SlotAddr::Master))
                 .unwrap()
         );
@@ -293,17 +341,17 @@ mod tests {
         let addresses = slot_map.addresses_for_all_primaries();
         assert_eq!(
             addresses,
-            HashSet::from_iter(["node1:6379", "node2:6379", "node3:6379"])
+            process_expected(vec!["node1:6379", "node2:6379", "node3:6379"])
         );
     }
 
     #[test]
     fn test_slot_map_get_all_nodes() {
         let slot_map = get_slot_map(ReadFromReplicaStrategy::AlwaysFromPrimary);
-        let addresses = slot_map.addresses_for_all_nodes();
+        let addresses = slot_map.all_node_addresses();
         assert_eq!(
             addresses,
-            HashSet::from_iter([
+            process_expected(vec![
                 "node1:6379",
                 "node2:6379",
                 "node3:6379",
@@ -327,11 +375,11 @@ mod tests {
         let addresses = slot_map
             .addresses_for_multi_slot(&routes)
             .collect::<Vec<_>>();
-        assert!(addresses.contains(&Some("node1:6379")));
+        assert!(addresses.contains(&Some(Arc::new("node1:6379".to_string()))));
         assert!(
-            addresses.contains(&Some("replica4:6379"))
-                || addresses.contains(&Some("replica5:6379"))
-                || addresses.contains(&Some("replica6:6379"))
+            addresses.contains(&Some(Arc::new("replica4:6379".to_string())))
+                || addresses.contains(&Some(Arc::new("replica5:6379".to_string())))
+                || addresses.contains(&Some(Arc::new("replica6:6379".to_string())))
         );
     }
 
@@ -348,19 +396,21 @@ mod tests {
             (Route::new(3, SlotAddr::ReplicaOptional), vec![]),
             (Route::new(2003, SlotAddr::Master), vec![]),
         ];
-        let addresses = slot_map
+        let addresses: Vec<Arc<String>> = slot_map
             .addresses_for_multi_slot(&routes)
-            .collect::<Vec<_>>();
+            .flatten()
+            .collect();
+
         assert_eq!(
             addresses,
-            vec![
+            process_expected_with_option(vec![
                 Some("replica1:6379"),
                 Some("node3:6379"),
                 Some("replica1:6379"),
                 Some("node3:6379"),
                 Some("replica1:6379"),
                 Some("node3:6379")
-            ]
+            ])
         );
     }
 
@@ -373,12 +423,19 @@ mod tests {
             (Route::new(6000, SlotAddr::ReplicaOptional), vec![]),
             (Route::new(2002, SlotAddr::Master), vec![]),
         ];
-        let addresses = slot_map
+        let addresses: Vec<Arc<String>> = slot_map
             .addresses_for_multi_slot(&routes)
-            .collect::<Vec<_>>();
+            .flatten()
+            .collect();
+
         assert_eq!(
             addresses,
-            vec![Some("replica1:6379"), None, None, Some("node3:6379")]
+            process_expected_with_option(vec![
+                Some("replica1:6379"),
+                None,
+                None,
+                Some("node3:6379")
+            ])
         );
     }
 
@@ -395,6 +452,9 @@ mod tests {
         assert_eq!(
             addresses,
             vec!["replica4:6379", "replica5:6379", "replica6:6379"]
+                .into_iter()
+                .map(|s| Arc::new(s.to_string()))
+                .collect::<Vec<_>>()
         );
     }
 
@@ -402,33 +462,33 @@ mod tests {
     fn test_get_slots_of_node() {
         let slot_map = get_slot_map(ReadFromReplicaStrategy::AlwaysFromPrimary);
         assert_eq!(
-            slot_map.get_slots_of_node("node1:6379"),
+            slot_map.get_slots_of_node(Arc::new("node1:6379".to_string())),
             (1..1001).collect::<Vec<u16>>()
         );
         assert_eq!(
-            slot_map.get_slots_of_node("node2:6379"),
+            slot_map.get_slots_of_node(Arc::new("node2:6379".to_string())),
             vec![1002..2001, 3001..4001]
                 .into_iter()
                 .flatten()
                 .collect::<Vec<u16>>()
         );
         assert_eq!(
-            slot_map.get_slots_of_node("replica3:6379"),
+            slot_map.get_slots_of_node(Arc::new("replica3:6379".to_string())),
             vec![1002..2001, 3001..4001]
                 .into_iter()
                 .flatten()
                 .collect::<Vec<u16>>()
         );
         assert_eq!(
-            slot_map.get_slots_of_node("replica4:6379"),
+            slot_map.get_slots_of_node(Arc::new("replica4:6379".to_string())),
             (2001..3001).collect::<Vec<u16>>()
         );
         assert_eq!(
-            slot_map.get_slots_of_node("replica5:6379"),
+            slot_map.get_slots_of_node(Arc::new("replica5:6379".to_string())),
             (2001..3001).collect::<Vec<u16>>()
         );
         assert_eq!(
-            slot_map.get_slots_of_node("replica6:6379"),
+            slot_map.get_slots_of_node(Arc::new("replica6:6379".to_string())),
             (2001..3001).collect::<Vec<u16>>()
         );
     }

--- a/redis/src/cluster_topology.rs
+++ b/redis/src/cluster_topology.rs
@@ -504,19 +504,18 @@ mod tests {
     }
 
     fn get_node_addr(name: &str, port: u16) -> ShardAddrs {
-        ShardAddrs {
-            primary: format!("{name}:{port}").into(),
-            replicas: Vec::new(),
-        }
+        ShardAddrs::new(format!("{name}:{port}").into(), Vec::new())
     }
 
     fn collect_shard_addrs(slot_map: &SlotMap) -> Vec<ShardAddrs> {
         let mut shard_addrs: Vec<ShardAddrs> = slot_map
-            .nodes_map
+            .nodes_map()
             .iter()
             .map(|map_item| {
                 let shard_addrs = map_item.value();
-                let addr_reader = shard_addrs.read().unwrap();
+                let addr_reader = shard_addrs
+                    .read()
+                    .expect("Failed to obtain ShardAddrs's read lock");
                 addr_reader.clone()
             })
             .collect();


### PR DESCRIPTION
This PR lays the foundation for supporting topology changes triggered by MOVED errors.

Slot Map Design

Currently, our slot map contains only a tree structure representing the slots and their associated ShardAddr, which holds the primary and replica addresses. For non-consecutive slots owned by the same shard, a new ShardAddr is created. The proposed design introduces the following enhancements:

1. Addition of a NodesMap: This map will store node identifiers (host:port) as keys, with their corresponding ShardAddrs as values. This allows primary and replicas of the same shard to share the same ShardAddr, reducing redundancy.
2. Read/Write Lock on ShardAddr: The ShardAddr will be wrapped in a read/write lock. The write lock will only be used when changes to the shard addresses are necessary due to MOVED errors (for example when a MOVED error suggests a failover, or in scenarios when a replica is removed from existing ShardAddr as it is promoted to a primary in a different shard).


This design allows for fast address retrieval for routing while enabling synchronized updates across multiple slots, even if they are non-consecutive. In the SlotMap’s binary tree, non-consecutive slots owned by the same shard are represented by different tree nodes for each range. In the proposed design, all these tree nodes will share the same ShardAddrs. As a result, when a ShardAddrs is updated due to a MOVED error for one slot, the change will automatically apply to all other slots owned by the same shard.


The diagram on the left represents the current design of SlotMap, while the diagram on the right illustrates the new design.
![image](https://github.com/user-attachments/assets/7cc587cb-fb9a-4230-bc2f-ea90dfdc2073)

Full example:
![image](https://github.com/user-attachments/assets/9d7d894d-2b90-43cb-b9a7-4379fcf65e17)
