### PR TITLE
Added logic to update the slot map based on MOVED errors

### DIFF
--- a/redis/benches/bench_basic.rs
+++ b/redis/benches/bench_basic.rs
@@ -31,10 +31,13 @@ fn bench_simple_getsetdel_async(b: &mut Bencher) {
                 redis::cmd("SET")
                     .arg(key)
                     .arg(42)
-                    .query_async(&mut con)
+                    .query_async::<_, Option<Value>>(&mut con)
                     .await?;
                 let _: isize = redis::cmd("GET").arg(key).query_async(&mut con).await?;
-                redis::cmd("DEL").arg(key).query_async(&mut con).await?;
+                redis::cmd("DEL")
+                    .arg(key)
+                    .query_async::<_, Option<Value>>(&mut con)
+                    .await?;
                 Ok::<_, RedisError>(())
             })
             .unwrap()

--- a/redis/benches/bench_cluster_async.rs
+++ b/redis/benches/bench_cluster_async.rs
@@ -21,9 +21,16 @@ fn bench_cluster_async(
             runtime
                 .block_on(async {
                     let key = "test_key";
-                    redis::cmd("SET").arg(key).arg(42).query_async(con).await?;
+                    redis::cmd("SET")
+                        .arg(key)
+                        .arg(42)
+                        .query_async::<_, Option<redis::Value>>(con)
+                        .await?;
                     let _: isize = redis::cmd("GET").arg(key).query_async(con).await?;
-                    redis::cmd("DEL").arg(key).query_async(con).await?;
+                    redis::cmd("DEL")
+                        .arg(key)
+                        .query_async::<_, Option<redis::Value>>(con)
+                        .await?;
 
                     Ok::<_, RedisError>(())
                 })

--- a/redis/src/cluster_async/connections_container.rs
+++ b/redis/src/cluster_async/connections_container.rs
@@ -1,11 +1,13 @@
 use crate::cluster_async::ConnectionFuture;
-use crate::cluster_routing::{Route, SlotAddr};
+use crate::cluster_routing::{Route, ShardAddrs, SlotAddr};
 use crate::cluster_slotmap::{ReadFromReplicaStrategy, SlotMap, SlotMapValue};
 use crate::cluster_topology::TopologyHash;
 use dashmap::DashMap;
 use futures::FutureExt;
 use rand::seq::IteratorRandom;
 use std::net::IpAddr;
+use std::sync::Arc;
+use std::sync::RwLock;
 
 /// A struct that encapsulates a network connection along with its associated IP address.
 #[derive(Clone, Eq, PartialEq, Debug)]
@@ -135,6 +137,16 @@ where
             read_from_replica_strategy,
             topology_hash,
         }
+    }
+
+    /// Returns an iterator over the nodes in the `slot_map`, yielding pairs of the node address and its associated shard addresses.
+    pub(crate) fn slot_map_nodes(
+        &self,
+    ) -> impl Iterator<Item = (Arc<String>, Arc<RwLock<ShardAddrs>>)> + '_ {
+        self.slot_map
+            .nodes_map()
+            .iter()
+            .map(|item| (item.key().clone(), item.value().clone()))
     }
 
     // Extends the current connection map with the provided one

--- a/redis/src/cluster_async/connections_container.rs
+++ b/redis/src/cluster_async/connections_container.rs
@@ -7,7 +7,6 @@ use futures::FutureExt;
 use rand::seq::IteratorRandom;
 use std::net::IpAddr;
 use std::sync::Arc;
-use std::sync::RwLock;
 
 /// A struct that encapsulates a network connection along with its associated IP address.
 #[derive(Clone, Eq, PartialEq, Debug)]
@@ -142,7 +141,7 @@ where
     /// Returns an iterator over the nodes in the `slot_map`, yielding pairs of the node address and its associated shard addresses.
     pub(crate) fn slot_map_nodes(
         &self,
-    ) -> impl Iterator<Item = (Arc<String>, Arc<RwLock<ShardAddrs>>)> + '_ {
+    ) -> impl Iterator<Item = (Arc<String>, Arc<ShardAddrs>)> + '_ {
         self.slot_map
             .nodes_map()
             .iter()
@@ -166,10 +165,7 @@ where
         &self,
         slot_map_value: &SlotMapValue,
     ) -> Option<ConnectionAndAddress<Connection>> {
-        let addrs = &slot_map_value
-            .addrs
-            .read()
-            .expect("Failed to obtain ShardAddrs's read lock");
+        let addrs = &slot_map_value.addrs;
         let initial_index = slot_map_value
             .last_used_replica
             .load(std::sync::atomic::Ordering::Relaxed);
@@ -197,10 +193,7 @@ where
 
     fn lookup_route(&self, route: &Route) -> Option<ConnectionAndAddress<Connection>> {
         let slot_map_value = self.slot_map.slot_value_for_route(route)?;
-        let addrs = &slot_map_value
-            .addrs
-            .read()
-            .expect("Failed to obtain ShardAddrs's read lock");
+        let addrs = &slot_map_value.addrs;
         if addrs.replicas().is_empty() {
             return self.connection_for_address(addrs.primary().as_str());
         }

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -635,9 +635,7 @@ pub(crate) struct RedirectNode {
 }
 
 impl RedirectNode {
-    /// This function expects an `Option` containing a tuple with a string slice and a u16.
-    /// The tuple represents an address and a slot, respectively. If the input is `Some`,
-    /// the function converts the address to a `String` and constructs a `RedirectNode`.
+    /// Constructs a `RedirectNode` from an optional tuple containing an address and a slot number.
     pub(crate) fn from_option_tuple(option: Option<(&str, u16)>) -> Option<Self> {
         option.map(|(address, slot)| RedirectNode {
             address: address.to_string(),
@@ -828,8 +826,8 @@ impl<C> Future for Request<C> {
                     // Updating the slot map based on the MOVED error is an optimization.
                     // If it fails, proceed by retrying the request with the redirected node,
                     // and allow the slot refresh task to correct the slot map.
-                    warn!(
-                        "Failed to update the slot map based on the received MOVED error.\n
+                    info!(
+                        "Failed to update the slot map based on the received MOVED error.
                         Error: {err:?}"
                     );
                 }
@@ -1739,7 +1737,7 @@ where
                 // Scenario 1: No changes needed as the new primary is already the current slot owner.
                 // Scenario 2: Failover occurred and the new primary was promoted from a replica.
                 ShardUpdateResult::AlreadyPrimary | ShardUpdateResult::Promoted => return Ok(()),
-                // If the node was not found, proceed with further scenarios.
+                // The node was not found in this shard, proceed with further scenarios.
                 ShardUpdateResult::NodeNotFound => {}
             }
         }

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -1731,7 +1731,7 @@ where
         slot: u16,
         new_primary: Arc<String>,
     ) -> RedisResult<()> {
-        let connections_container = inner.conn_lock.read().await;
+        let mut connections_container = inner.conn_lock.write().await;
         let curr_shard_addrs = connections_container.slot_map.shard_addrs_for_slot(slot);
         // Check if the new primary is part of the current shard and update if required
         if let Some(curr_shard_addrs) = curr_shard_addrs {
@@ -1744,9 +1744,6 @@ where
             }
         }
 
-        // Further changes are needed, acquire the write lock on the connection container
-        drop(connections_container);
-        let mut connections_container = inner.conn_lock.write().await;
         // Scenario 3 & 4: Check if the new primary exists in other shards
         let mut nodes_iter = connections_container.slot_map_nodes();
         for (node_addr, shard_addrs_arc) in &mut nodes_iter {

--- a/redis/src/cluster_slotmap.rs
+++ b/redis/src/cluster_slotmap.rs
@@ -109,7 +109,6 @@ impl SlotMap {
         slot_map
     }
 
-    #[allow(dead_code)] // used in tests
     pub(crate) fn nodes_map(&self) -> &NodesMap {
         &self.nodes_map
     }

--- a/redis/src/cluster_topology.rs
+++ b/redis/src/cluster_topology.rs
@@ -503,20 +503,17 @@ mod tests {
         }
     }
 
-    fn get_node_addr(name: &str, port: u16) -> ShardAddrs {
-        ShardAddrs::new(format!("{name}:{port}").into(), Vec::new())
+    fn get_node_addr(name: &str, port: u16) -> Arc<ShardAddrs> {
+        Arc::new(ShardAddrs::new(format!("{name}:{port}").into(), Vec::new()))
     }
 
-    fn collect_shard_addrs(slot_map: &SlotMap) -> Vec<ShardAddrs> {
-        let mut shard_addrs: Vec<ShardAddrs> = slot_map
+    fn collect_shard_addrs(slot_map: &SlotMap) -> Vec<Arc<ShardAddrs>> {
+        let mut shard_addrs: Vec<Arc<ShardAddrs>> = slot_map
             .nodes_map()
             .iter()
             .map(|map_item| {
                 let shard_addrs = map_item.value();
-                let addr_reader = shard_addrs
-                    .read()
-                    .expect("Failed to obtain ShardAddrs's read lock");
-                addr_reader.clone()
+                shard_addrs.clone()
             })
             .collect();
         shard_addrs.sort_unstable();
@@ -543,7 +540,7 @@ mod tests {
         .unwrap();
         let res = collect_shard_addrs(&topology_view);
         let node_1 = get_node_addr("node1", 6379);
-        let expected: Vec<ShardAddrs> = vec![node_1];
+        let expected = vec![node_1];
         assert_eq!(res, expected);
     }
 
@@ -586,7 +583,7 @@ mod tests {
         let res = collect_shard_addrs(&topology_view);
         let node_1 = get_node_addr("node1", 6379);
         let node_2 = get_node_addr("node2", 6380);
-        let expected: Vec<ShardAddrs> = vec![node_1, node_2];
+        let expected = vec![node_1, node_2];
         assert_eq!(res, expected);
     }
 
@@ -609,7 +606,7 @@ mod tests {
         let res = collect_shard_addrs(&topology_view);
         let node_1 = get_node_addr("node1", 6379);
         let node_2 = get_node_addr("node2", 6380);
-        let expected: Vec<ShardAddrs> = vec![node_1, node_2];
+        let expected = vec![node_1, node_2];
         assert_eq!(res, expected);
     }
 
@@ -633,7 +630,7 @@ mod tests {
         let res = collect_shard_addrs(&topology_view);
         let node_1 = get_node_addr("node3", 6381);
         let node_2 = get_node_addr("node4", 6382);
-        let expected: Vec<ShardAddrs> = vec![node_1, node_2];
+        let expected = vec![node_1, node_2];
         assert_eq!(res, expected);
     }
 
@@ -656,7 +653,7 @@ mod tests {
         .unwrap();
         let res = collect_shard_addrs(&topology_view);
         let node_1 = get_node_addr("node1", 6379);
-        let expected: Vec<ShardAddrs> = vec![node_1];
+        let expected = vec![node_1];
         assert_eq!(res, expected);
     }
 }

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -642,7 +642,7 @@ pub fn build_keys_and_certs_for_tls(tempdir: &TempDir) -> TlsFilePaths {
             .arg("genrsa")
             .arg("-out")
             .arg(name)
-            .arg(&format!("{size}"))
+            .arg(format!("{size}"))
             .stdout(process::Stdio::null())
             .stderr(process::Stdio::null())
             .spawn()

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -1318,63 +1318,83 @@ mod cluster_async {
     }
 
     #[test]
-    fn test_async_cluster_update_slots_based_on_moved_error() {
-        let name = "test_async_cluster_update_slots_based_on_moved_error";
+    fn test_async_cluster_update_slots_based_on_moved_error_indicates_slot_migration() {
+        // This test simulates the scenario where the client receives a MOVED error indicating that a key is now
+        // stored on the primary node of another shard.
+        // It ensures that the new slot now owned by the primary and its associated replicas.
+        let name = "test_async_cluster_update_slots_based_on_moved_error_indicates_slot_migration";
+        let slots_config = vec![
+            MockSlotRange {
+                primary_port: 6379,
+                replica_ports: vec![7000],
+                slot_range: (0..8000),
+            },
+            MockSlotRange {
+                primary_port: 6380,
+                replica_ports: vec![7001],
+                slot_range: (8001..16380),
+            },
+        ];
 
-        let should_refresh = atomic::AtomicBool::new(false);
+        let moved_from_port = 6379;
+        let moved_to_port = 6380;
+        let new_shard_replica_port = 7001;
 
+        // Tracking moved and replica requests for validation
+        let moved_requests = Arc::new(atomic::AtomicUsize::new(0));
+        let cloned_moved_requests = moved_requests.clone();
+        let replica_requests = Arc::new(atomic::AtomicUsize::new(0));
+        let cloned_replica_requests = moved_requests.clone();
+
+        // Test key and slot
+        let key = "test";
+        let key_slot = 6918;
+
+        // Mock environment setup
         let MockEnv {
             runtime,
             async_connection: mut connection,
             handler: _handler,
             ..
         } = MockEnv::with_client_builder(
-            ClusterClient::builder(vec![&*format!("redis://{name}")])                
-            // Enable the rate limiter with high value so it won't refresh the slots 
-            .slots_refresh_rate_limit(Duration::from_secs(1000000), 0),
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                    .slots_refresh_rate_limit(Duration::from_secs(1000000), 0) // Rate limiter to disable slot refresh
+                    .read_from_replicas(), // Allow reads from replicas
             name,
             move |cmd: &[u8], port| {
-                if contains_slice(cmd, b"PING") || contains_slice(cmd, b"SETNAME") {
+                if contains_slice(cmd, b"PING")
+                    || contains_slice(cmd, b"SETNAME")
+                    || contains_slice(cmd, b"READONLY")
+                {
                     return Err(Ok(Value::SimpleString("OK".into())));
                 }
 
                 if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
-                    return Err(Ok(Value::Array(vec![
-                        Value::Array(vec![
-                            Value::Int(0),
-                            Value::Int(16382),
-                            Value::Array(vec![
-                                Value::BulkString(name.as_bytes().to_vec()),
-                                Value::Int(6379),
-                            ]),
-                        ]),
-                        Value::Array(vec![
-                            Value::Int(16382),
-                            Value::Int(16383),
-                            Value::Array(vec![
-                                Value::BulkString(name.as_bytes().to_vec()),
-                                Value::Int(6380),
-                            ]),
-                        ]),
-                    ])));
+                    let slots = create_topology_from_config(name, slots_config.clone());
+                    return Err(Ok(slots));
                 }
 
-                if contains_slice(cmd, b"GET") {
-                    let get_response = Err(Ok(Value::BulkString(b"123".to_vec())));
-                    match port {
-                        6380 => {
-                            println!("received request {:?}", std::str::from_utf8(cmd));
-                            get_response
-                        }
-                        // Respond that the key exists on a node that does not yet have a connection:
-                        _ => {
-                            println!("hereee");
-                            // Should not attempt to refresh slots more than once:
-                            assert!(!should_refresh.swap(true, Ordering::SeqCst));
-                            Err(parse_redis_value(
-                                format!("-MOVED 123 {name}:6380\r\n").as_bytes(),
-                            ))
-                        }
+                if contains_slice(cmd, b"SET") {
+                    if port == moved_to_port {
+                        // Simulate primary OK response
+                        Err(Ok(Value::SimpleString("OK".into())))
+                    } else if port == moved_from_port {
+                        // Simulate MOVED error for other port
+                        moved_requests.fetch_add(1, Ordering::Relaxed);
+                        Err(parse_redis_value(
+                            format!("-MOVED {key_slot} {name}:{moved_to_port}\r\n").as_bytes(),
+                        ))
+                    } else {
+                        panic!("unexpected port for SET command: {port:?}.\n
+                            Expected one of: moved_to_port={moved_to_port}, moved_from_port={moved_from_port}");
+                    }
+                } else if contains_slice(cmd, b"GET") {
+                    if new_shard_replica_port == port {
+                        // Simulate replica response for GET after slot migration
+                        replica_requests.fetch_add(1, Ordering::Relaxed);
+                        Err(Ok(Value::BulkString(b"123".to_vec())))
+                    } else {
+                        panic!("unexpected port for GET command: {port:?}, Expected: {new_shard_replica_port:?}");
                     }
                 } else {
                     panic!("unexpected command {cmd:?}")
@@ -1382,13 +1402,468 @@ mod cluster_async {
             },
         );
 
+        // First request: Trigger MOVED error and reroute
+        let value = runtime.block_on(
+            cmd("SET")
+                .arg(key)
+                .arg("bar")
+                .query_async::<_, Option<Value>>(&mut connection),
+        );
+        assert_eq!(value, Ok(Some(Value::SimpleString("OK".to_owned()))));
+
+        // Second request: Should be routed directly to the new primary node if the slots map is updated
+        let value = runtime.block_on(
+            cmd("SET")
+                .arg(key)
+                .arg("bar")
+                .query_async::<_, Option<Value>>(&mut connection),
+        );
+        assert_eq!(value, Ok(Some(Value::SimpleString("OK".to_owned()))));
+
+        // Handle slot migration scenario: Ensure the new shard's replicas are accessible
         let value = runtime.block_on(
             cmd("GET")
-                .arg("test")
+                .arg(key)
                 .query_async::<_, Option<i32>>(&mut connection),
         );
-
         assert_eq!(value, Ok(Some(123)));
+        assert_eq!(cloned_replica_requests.load(Ordering::Relaxed), 1);
+
+        // Assert there was only a single MOVED error
+        assert_eq!(cloned_moved_requests.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn test_async_cluster_update_slots_based_on_moved_error_indicates_failover() {
+        // This test simulates a failover scenario, where the client receives a MOVED error and the replica becomes the new primary.
+        // The test verifies that the client updates the slot mapping to promote the replica to the primary and routes future requests
+        // to the new primary, ensuring other slots in the shard are also handled by the new primary.
+        let name = "test_async_cluster_update_slots_based_on_moved_error_indicates_failover";
+        let slots_config = vec![
+            MockSlotRange {
+                primary_port: 6379,
+                replica_ports: vec![7001],
+                slot_range: (0..8000),
+            },
+            MockSlotRange {
+                primary_port: 6380,
+                replica_ports: vec![7002],
+                slot_range: (8001..16380),
+            },
+        ];
+
+        let moved_from_port = 6379;
+        let moved_to_port = 7001;
+
+        // Tracking moved for validation
+        let moved_requests = Arc::new(atomic::AtomicUsize::new(0));
+        let cloned_moved_requests = moved_requests.clone();
+
+        // Test key and slot
+        let key = "test";
+        let key_slot = 6918;
+
+        // Mock environment setup
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                .slots_refresh_rate_limit(Duration::from_secs(1000000), 0), // Rate limiter to disable slot refresh
+            name,
+            move |cmd: &[u8], port| {
+                if contains_slice(cmd, b"PING")
+                    || contains_slice(cmd, b"SETNAME")
+                    || contains_slice(cmd, b"READONLY")
+                {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+
+                if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
+                    let slots = create_topology_from_config(name, slots_config.clone());
+                    return Err(Ok(slots));
+                }
+
+                if contains_slice(cmd, b"SET") {
+                    if port == moved_to_port {
+                        // Simulate primary OK response
+                        Err(Ok(Value::SimpleString("OK".into())))
+                    } else if port == moved_from_port {
+                        // Simulate MOVED error for other port
+                        moved_requests.fetch_add(1, Ordering::Relaxed);
+                        Err(parse_redis_value(
+                            format!("-MOVED {key_slot} {name}:{moved_to_port}\r\n").as_bytes(),
+                        ))
+                    } else {
+                        panic!("unexpected port for SET command: {port:?}.\n
+                            Expected one of: moved_to_port={moved_to_port}, moved_from_port={moved_from_port}");
+                    }
+                } else {
+                    panic!("unexpected command {cmd:?}")
+                }
+            },
+        );
+
+        // First request: Trigger MOVED error and reroute
+        let value = runtime.block_on(
+            cmd("SET")
+                .arg(key)
+                .arg("bar")
+                .query_async::<_, Option<Value>>(&mut connection),
+        );
+        assert_eq!(value, Ok(Some(Value::SimpleString("OK".to_owned()))));
+
+        // Second request: Should be routed directly to the new primary node if the slots map is updated
+        let value = runtime.block_on(
+            cmd("SET")
+                .arg(key)
+                .arg("bar")
+                .query_async::<_, Option<Value>>(&mut connection),
+        );
+        assert_eq!(value, Ok(Some(Value::SimpleString("OK".to_owned()))));
+
+        // Handle failover scenario: Ensure other slots in the same shard are updated to the new primary
+        let key_slot_1044 = "foo2";
+        let value = runtime.block_on(
+            cmd("SET")
+                .arg(key_slot_1044)
+                .arg("bar2")
+                .query_async::<_, Option<Value>>(&mut connection),
+        );
+        assert_eq!(value, Ok(Some(Value::SimpleString("OK".to_owned()))));
+
+        // Assert there was only a single MOVED error
+        assert_eq!(cloned_moved_requests.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn test_async_cluster_update_slots_based_on_moved_error_indicates_new_primary() {
+        // This test simulates the scenario where the client receives a MOVED error indicating that the key now belongs to
+        // an entirely new primary node that wasn't previously known. The test verifies that the client correctly adds the new
+        // primary node to its slot map and routes future requests to the new node.
+        let name = "test_async_cluster_update_slots_based_on_moved_error_indicates_new_primary";
+        let slots_config = vec![
+            MockSlotRange {
+                primary_port: 6379,
+                replica_ports: vec![],
+                slot_range: (0..8000),
+            },
+            MockSlotRange {
+                primary_port: 6380,
+                replica_ports: vec![],
+                slot_range: (8001..16380),
+            },
+        ];
+
+        let moved_from_port = 6379;
+        let moved_to_port = 6381;
+
+        // Tracking moved for validation
+        let moved_requests = Arc::new(atomic::AtomicUsize::new(0));
+        let cloned_moved_requests = moved_requests.clone();
+
+        // Test key and slot
+        let key = "test";
+        let key_slot = 6918;
+
+        // Mock environment setup
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+            .slots_refresh_rate_limit(Duration::from_secs(1000000), 0) // Rate limiter to disable slot refresh
+            .read_from_replicas(), // Allow reads from replicas
+            name,
+            move |cmd: &[u8], port| {
+                if contains_slice(cmd, b"PING")
+                    || contains_slice(cmd, b"SETNAME")
+                    || contains_slice(cmd, b"READONLY")
+                {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+
+                if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
+                    let slots = create_topology_from_config(name, slots_config.clone());
+                    return Err(Ok(slots));
+                }
+
+                if contains_slice(cmd, b"SET") {
+                    if port == moved_to_port {
+                        // Simulate primary OK response
+                        Err(Ok(Value::SimpleString("OK".into())))
+                    } else if port == moved_from_port {
+                        // Simulate MOVED error for other port
+                        moved_requests.fetch_add(1, Ordering::Relaxed);
+                        Err(parse_redis_value(
+                            format!("-MOVED {key_slot} {name}:{moved_to_port}\r\n").as_bytes(),
+                        ))
+                    } else {
+                        panic!("unexpected port for SET command: {port:?}.\n
+                    Expected one of: moved_to_port={moved_to_port}, moved_from_port={moved_from_port}");
+                    }
+                } else if contains_slice(cmd, b"GET") {
+                    if moved_to_port == port {
+                        // Simulate primary response for GET
+                        Err(Ok(Value::BulkString(b"123".to_vec())))
+                    } else {
+                        panic!(
+                            "unexpected port for GET command: {port:?}, Expected: {moved_to_port}"
+                        );
+                    }
+                } else {
+                    panic!("unexpected command {cmd:?}")
+                }
+            },
+        );
+
+        // First request: Trigger MOVED error and reroute
+        let value = runtime.block_on(
+            cmd("SET")
+                .arg(key)
+                .arg("bar")
+                .query_async::<_, Option<Value>>(&mut connection),
+        );
+        assert_eq!(value, Ok(Some(Value::SimpleString("OK".to_owned()))));
+
+        // Second request: Should be routed directly to the new primary node if the slots map is updated
+        let value = runtime.block_on(
+            cmd("SET")
+                .arg(key)
+                .arg("bar")
+                .query_async::<_, Option<Value>>(&mut connection),
+        );
+        assert_eq!(value, Ok(Some(Value::SimpleString("OK".to_owned()))));
+
+        // Third request: The new primary should have no replicas so it should be directed to it
+        let value = runtime.block_on(
+            cmd("GET")
+                .arg(key)
+                .query_async::<_, Option<i32>>(&mut connection),
+        );
+        assert_eq!(value, Ok(Some(123)));
+
+        // Assert there was only a single MOVED error
+        assert_eq!(cloned_moved_requests.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn test_async_cluster_update_slots_based_on_moved_error_indicates_replica_of_different_shard() {
+        // This test simulates a scenario where the client receives a MOVED error indicating that a key
+        // has been moved to a replica in a different shard. The replica is then promoted to primary and
+        // no longer exists in the shard’s replica set.
+        // The test validates that the key gets correctly routed to the new primary and ensures that the
+        // shard updates its mapping accordingly, with only one MOVED error encountered during the process.
+
+        let name = "test_async_cluster_update_slots_based_on_moved_error_indicates_replica_of_different_shard";
+        let slots_config = vec![
+            MockSlotRange {
+                primary_port: 6379,
+                replica_ports: vec![7000],
+                slot_range: (0..8000),
+            },
+            MockSlotRange {
+                primary_port: 6380,
+                replica_ports: vec![7001],
+                slot_range: (8001..16380),
+            },
+        ];
+
+        let moved_from_port = 6379;
+        let moved_to_port = 7001;
+        let primary_shard2 = 6380;
+
+        // Tracking moved for validation
+        let moved_requests = Arc::new(atomic::AtomicUsize::new(0));
+        let cloned_moved_requests = moved_requests.clone();
+
+        // Test key and slot of the first shard
+        let key = "test";
+        let key_slot = 6918;
+
+        // Test key of the second shard
+        let key_shard2 = "foo"; // slot 12182
+
+        // Mock environment setup
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                    .slots_refresh_rate_limit(Duration::from_secs(1000000), 0) // Rate limiter to disable slot refresh
+                    .read_from_replicas(), // Allow reads from replicas
+            name,
+            move |cmd: &[u8], port| {
+                if contains_slice(cmd, b"PING")
+                    || contains_slice(cmd, b"SETNAME")
+                    || contains_slice(cmd, b"READONLY")
+                {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+
+                if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
+                    let slots = create_topology_from_config(name, slots_config.clone());
+                    return Err(Ok(slots));
+                }
+
+                if contains_slice(cmd, b"SET") {
+                    if port == moved_to_port {
+                        // Simulate primary OK response
+                        Err(Ok(Value::SimpleString("OK".into())))
+                    } else if port == moved_from_port {
+                        // Simulate MOVED error for other port
+                        moved_requests.fetch_add(1, Ordering::Relaxed);
+                        Err(parse_redis_value(
+                            format!("-MOVED {key_slot} {name}:{moved_to_port}\r\n").as_bytes(),
+                        ))
+                    } else {
+                        panic!("unexpected port for SET command: {port:?}.\n
+                            Expected one of: moved_to_port={moved_to_port}, moved_from_port={moved_from_port}");
+                    }
+                } else if contains_slice(cmd, b"GET") {
+                    if port == primary_shard2 {
+                        // Simulate second shard primary response for GET
+                        Err(Ok(Value::BulkString(b"123".to_vec())))
+                    } else {
+                        panic!("unexpected port for GET command: {port:?}, Expected: {primary_shard2:?}");
+                    }
+                } else {
+                    panic!("unexpected command {cmd:?}")
+                }
+            },
+        );
+
+        // First request: Trigger MOVED error and reroute
+        let value = runtime.block_on(
+            cmd("SET")
+                .arg(key)
+                .arg("bar")
+                .query_async::<_, Option<Value>>(&mut connection),
+        );
+        assert_eq!(value, Ok(Some(Value::SimpleString("OK".to_owned()))));
+
+        // Second request: Should be routed directly to the new primary node if the slots map is updated
+        let value = runtime.block_on(
+            cmd("SET")
+                .arg(key)
+                .arg("bar")
+                .query_async::<_, Option<Value>>(&mut connection),
+        );
+        assert_eq!(value, Ok(Some(Value::SimpleString("OK".to_owned()))));
+
+        // Third request: Verify that the promoted replica is no longer part of the second shard replicas by
+        // ensuring the response is received from the shard's primary
+        let value = runtime.block_on(
+            cmd("GET")
+                .arg(key_shard2)
+                .query_async::<_, Option<i32>>(&mut connection),
+        );
+        assert_eq!(value, Ok(Some(123)));
+
+        // Assert there was only a single MOVED error
+        assert_eq!(cloned_moved_requests.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn test_async_cluster_update_slots_based_on_moved_error_no_change() {
+        // This test simulates a scenario where the client receives a MOVED error, but the new primary is the
+        // same as the old primary (no actual change). It ensures that no additional slot map
+        // updates are required and that the subsequent requests are still routed to the same primary node, with
+        // only one MOVED error encountered.
+        let name = "test_async_cluster_update_slots_based_on_moved_error_no_change";
+        let slots_config = vec![
+            MockSlotRange {
+                primary_port: 6379,
+                replica_ports: vec![7000],
+                slot_range: (0..8000),
+            },
+            MockSlotRange {
+                primary_port: 6380,
+                replica_ports: vec![7001],
+                slot_range: (8001..16380),
+            },
+        ];
+
+        let moved_from_port = 6379;
+        let moved_to_port = 6379;
+
+        // Tracking moved for validation
+        let moved_requests = Arc::new(atomic::AtomicUsize::new(0));
+        let cloned_moved_requests = moved_requests.clone();
+
+        // Test key and slot of the first shard
+        let key = "test";
+        let key_slot = 6918;
+
+        // Mock environment setup
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                .slots_refresh_rate_limit(Duration::from_secs(1000000), 0), // Rate limiter to disable slot refresh
+            name,
+            move |cmd: &[u8], port| {
+                if contains_slice(cmd, b"PING")
+                    || contains_slice(cmd, b"SETNAME")
+                    || contains_slice(cmd, b"READONLY")
+                {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+
+                if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
+                    let slots = create_topology_from_config(name, slots_config.clone());
+                    return Err(Ok(slots));
+                }
+
+                if contains_slice(cmd, b"SET") {
+                    if port == moved_to_port {
+                        if moved_requests.load(Ordering::Relaxed) == 0 {
+                            moved_requests.fetch_add(1, Ordering::Relaxed);
+                            Err(parse_redis_value(
+                                format!("-MOVED {key_slot} {name}:{moved_to_port}\r\n").as_bytes(),
+                            ))
+                        } else {
+                            Err(Ok(Value::SimpleString("OK".into())))
+                        }
+                    } else {
+                        panic!("unexpected port for SET command: {port:?}.\n
+                            Expected one of: moved_to_port={moved_to_port}, moved_from_port={moved_from_port}");
+                    }
+                } else {
+                    panic!("unexpected command {cmd:?}")
+                }
+            },
+        );
+
+        // First request: Trigger MOVED error and reroute
+        let value = runtime.block_on(
+            cmd("SET")
+                .arg(key)
+                .arg("bar")
+                .query_async::<_, Option<Value>>(&mut connection),
+        );
+        assert_eq!(value, Ok(Some(Value::SimpleString("OK".to_owned()))));
+
+        // Second request: Should be still routed to the same primary node
+        let value = runtime.block_on(
+            cmd("SET")
+                .arg(key)
+                .arg("bar")
+                .query_async::<_, Option<Value>>(&mut connection),
+        );
+        assert_eq!(value, Ok(Some(Value::SimpleString("OK".to_owned()))));
+
+        // Assert there was only a single MOVED error
+        assert_eq!(cloned_moved_requests.load(Ordering::Relaxed), 1);
     }
 
     #[test]


### PR DESCRIPTION
Added logic to update the slot map based on MOVED errors. Now, when a MOVED error is received, the client will push a new future before retrying the request to attempt to update the slot map based on the new primary node, while still spawning a background task to refresh slots. This provides an optimization to ensure quicker rerouting of requests without waiting for the background slot refresh which can be skipped due to the rate limiter.

The updated logic handles several scenarios:

1. **No Change**: If the new primary is already the current slot owner, no changes are required.
2. **Failover**: If the new primary is a replica in the same shard, the client promotes the replica to primary by updating the shard's addresses.
3. **Slot Migration**: If the new primary is the existing primary of a different shard, the client updates the slot map to point to the new shard's addresses.
4. **Replica Moved to a Different Shard**: If the new primary is a replica in a different shard, it is either promoted to primary of its shard or moved to a new shard. The replica is removed from its original shard, and the slot map is updated accordingly.
5. **New Node**: If the new primary is an unknown node, the client adds it as a new primary node in a new shard, possibly indicating a scale-out.

If the slot map update fails, the request is retried with the moved redirect node, and the background slot refresh task will correct the map asynchronously.