### PR TITLE
Avoid retrying on IO errors when it’s unclear if the server received the request.

### DIFF
--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -370,8 +370,9 @@ where
             })
             .await
             .map_err(|err| {
-                // If an error occurs here, it means the request never reached the server.
-                // Since the server did not receive the data, it is safe to retry the request.
+                // If an error occurs here, it means the request never reached the server, as guaranteed
+                // by the 'send' function. Since the server did not receive the data, it is safe to retry
+                // the request.
                 RedisError::from((
                     crate::ErrorKind::IoErrorRetrySafe,
                     "Failed to send the request to the server",
@@ -384,6 +385,7 @@ where
                 // The `sender` was dropped which likely means that the stream part
                 // failed for one reason or another.
                 // Since we don't know if the server received the request, retrying it isn't safe.
+                // For example, retrying an INCR request could result in double increments.
                 // Hence, we return an IoError instead of an IoErrorRetrySafe.
                 Err(RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe)))
             }

--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -349,7 +349,7 @@ where
         &mut self,
         item: SinkItem,
         timeout: Duration,
-    ) -> Result<Value, Option<RedisError>> {
+    ) -> Result<Value, RedisError> {
         self.send_recv(item, None, timeout).await
     }
 
@@ -359,7 +359,7 @@ where
         // If `None`, this is a single request, not a pipeline of multiple requests.
         pipeline_response_count: Option<usize>,
         timeout: Duration,
-    ) -> Result<Value, Option<RedisError>> {
+    ) -> Result<Value, RedisError> {
         let (sender, receiver) = oneshot::channel();
 
         self.sender
@@ -369,15 +369,25 @@ where
                 output: sender,
             })
             .await
-            .map_err(|_| None)?;
+            .map_err(|err| {
+                // If an error occurs here, it means the request never reached the server.
+                // Since the server did not receive the data, it is safe to retry the request.
+                RedisError::from((
+                    crate::ErrorKind::IoErrorRetrySafe,
+                    "Failed to send the request to the server",
+                    format!("{err}"),
+                ))
+            })?;
         match Runtime::locate().timeout(timeout, receiver).await {
-            Ok(Ok(result)) => result.map_err(Some),
+            Ok(Ok(result)) => result,
             Ok(Err(_)) => {
                 // The `sender` was dropped which likely means that the stream part
-                // failed for one reason or another
-                Err(None)
+                // failed for one reason or another.
+                // Since we don't know if the server received the request, retrying it isn't safe.
+                // Hence, we return an IoError instead of an IoErrorRetrySafe.
+                Err(RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe)))
             }
-            Err(elapsed) => Err(Some(elapsed.into())),
+            Err(elapsed) => Err(elapsed.into()),
         }
     }
 
@@ -503,10 +513,7 @@ impl MultiplexedConnection {
         let result = self
             .pipeline
             .send_single(cmd.get_packed_command(), self.response_timeout)
-            .await
-            .map_err(|err| {
-                err.unwrap_or_else(|| RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe)))
-            });
+            .await;
         if self.protocol != ProtocolVersion::RESP2 {
             if let Err(e) = &result {
                 if e.is_connection_dropped() {
@@ -537,10 +544,7 @@ impl MultiplexedConnection {
                 Some(offset + count),
                 self.response_timeout,
             )
-            .await
-            .map_err(|err| {
-                err.unwrap_or_else(|| RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe)))
-            });
+            .await;
 
         if self.protocol != ProtocolVersion::RESP2 {
             if let Err(e) = &result {

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -771,7 +771,8 @@ where
                                 .wait_time_for_retry(retries);
                             thread::sleep(sleep_time);
                         }
-                        crate::types::RetryMethod::Reconnect => {
+                        crate::types::RetryMethod::Reconnect
+                        | crate::types::RetryMethod::ReconnectAndRetry => {
                             if *self.auto_reconnect.borrow() {
                                 if let Ok(mut conn) = self.connect(&addr) {
                                     if conn.check_connection() {

--- a/redis/src/cluster_async/connections_container.rs
+++ b/redis/src/cluster_async/connections_container.rs
@@ -654,13 +654,9 @@ mod tests {
         let container = create_container();
         remove_all_connections(&container);
 
-        assert_eq!(
-            0,
-            container
-                .random_connections(1, ConnectionType::User)
-                .expect("No connections found")
-                .count()
-        );
+        assert!(container
+            .random_connections(1, ConnectionType::User)
+            .is_none());
     }
 
     #[test]

--- a/redis/src/cluster_async/connections_container.rs
+++ b/redis/src/cluster_async/connections_container.rs
@@ -256,7 +256,7 @@ where
         amount: usize,
         conn_type: ConnectionType,
     ) -> Option<impl Iterator<Item = ConnectionAndAddress<Connection>> + '_> {
-        (!self.connection_map.is_empty()).then(|| {
+        (!self.connection_map.is_empty()).then_some({
             self.connection_map
                 .iter()
                 .choose_multiple(&mut rand::thread_rng(), amount)

--- a/redis/src/cluster_async/connections_container.rs
+++ b/redis/src/cluster_async/connections_container.rs
@@ -256,21 +256,17 @@ where
         amount: usize,
         conn_type: ConnectionType,
     ) -> Option<impl Iterator<Item = ConnectionAndAddress<Connection>> + '_> {
-        if self.connection_map.is_empty() {
-            None
-        } else {
-            Some(
-                self.connection_map
-                    .iter()
-                    .choose_multiple(&mut rand::thread_rng(), amount)
-                    .into_iter()
-                    .map(move |item| {
-                        let (address, node) = (item.key(), item.value());
-                        let conn = node.get_connection(&conn_type);
-                        (address.clone(), conn)
-                    }),
-            )
-        }
+        (!self.connection_map.is_empty()).then(|| {
+            self.connection_map
+                .iter()
+                .choose_multiple(&mut rand::thread_rng(), amount)
+                .into_iter()
+                .map(move |item| {
+                    let (address, node) = (item.key(), item.value());
+                    let conn = node.get_connection(&conn_type);
+                    (address.clone(), conn)
+                })
+        })
     }
 
     pub(crate) fn replace_or_add_connection_for_address(

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -569,7 +569,7 @@ mod basic_async {
                 Err(err) => break err,
             }
         };
-        assert_eq!(err.kind(), ErrorKind::IoError); // Shouldn't this be IoError?
+        assert_eq!(err.kind(), ErrorKind::IoErrorRetrySafe);
     }
 
     #[tokio::test]

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -2584,7 +2584,6 @@ mod cluster_async {
                 respond_startup_two_nodes(name, cmd)?;
                 let i = requests.fetch_add(1, atomic::Ordering::SeqCst);
                 match i {
-                    // Respond that the key exists on a node that does not yet have a connection:
                     0 => Err(Err(RedisError::from((ErrorKind::IoError, "io-error")))),
                     _ => {
                         panic!("Expected not to be retried!")
@@ -3224,7 +3223,7 @@ mod cluster_async {
             };
 
             // wait for new topology discovery
-            let max_requests = 10;
+            let max_requests = 5;
             let mut i = 0;
             let mut cmd = redis::cmd("INFO");
             cmd.arg("SERVER");
@@ -3294,9 +3293,8 @@ mod cluster_async {
             }
 
             if use_sharded {
-                let mut cmd = redis::cmd("SPUBLISH");
                 // validate SPUBLISH
-                let result = cmd
+                let result = redis::cmd("SPUBLISH")
                     .arg("test_channel_?")
                     .arg("test_message")
                     .query_async(&mut publishing_con)


### PR DESCRIPTION
### Main Change:
ATM, on I/O errors, we would reconnect to the failed node and retry the request if there were more retries left. This approach had a critical issue: we couldn’t reliably determine if the server had already received the request before the connection was broken. Retrying in such cases could result in duplicate command execution.

**Example:**
1. Client sends `INCR key`.
2. Server receives the request and increments the key (e.g., key = 1).
3. A network issue disconnects the client before the server can respond.
4. The client reconnects and retries the `INCR key`.
5. Server increments the key again (now key = 2). **BAD outcome**.

This PR differentiates between errors where it’s safe to retry and those where it’s not. Specifically, with multiplexed connections, if the `send` function returns an error, it guarantees that the server never received the data, making retries safe (see https://docs.rs/tokio/latest/tokio/sync/mpsc/struct.Sender.html#method.send). For other errors, where we can’t be certain, retries are unsafe and will not be automatically attempted. Instead, these errors will now be returned to the user, who must manually retry if they determine it’s safe.

### Test Changes:
Since I/O errors are now returned to the user, tests that previously killed the server now loop to retry the request, simulating the handling of I/O errors on the user side.

### Refresh Slots Change:
While testing this fix, I found that when all connections were unavailable and `refresh_slots` was called, it didn’t raise the expected `allConnectionsUnavailable` error. This has been fixed by updating `random_connections` function to return an `Option`. Now, if no connections are found, `refresh_slots` raises the `allConnectionsUnavailable` error immediately. The state then shifts to reconnecting to the initial nodes, and slot refreshes are attempted using the new connections.

### Out of Scope:
A future PR could introduce a new configuration option to enable retries on connection error, allowing users to control this behavior at the client level.